### PR TITLE
The S gear can't be used in the carstate of bluepilot

### DIFF
--- a/selfdrive/athena/registration.py
+++ b/selfdrive/athena/registration.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from datetime import datetime, timedelta
 from openpilot.common.api import api_get
-from openpilot.common.api.sunnylink import SunnylinkApi
 from openpilot.common.params import Params
 from openpilot.common.spinner import Spinner
 from openpilot.selfdrive.controls.lib.alertmanager import set_offroad_alert
@@ -86,8 +85,6 @@ def register(show_spinner=False) -> str | None:
 
       if time.monotonic() - start_time > 60 and show_spinner:
         spinner.update(f"registering device - serial: {serial}, IMEI: ({imei1}, {imei2})")
-
-    SunnylinkApi(dongle_id).register_device(spinner if show_spinner else None)
 
     if show_spinner:
       spinner.close()

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -83,20 +83,19 @@ class CarState(CarStateBase):
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:
-      if self.CP.flags & FordFlags.CANFD:
-        gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
-      elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
-           gear = self.shifter_values.get(cp.vl["TransGearData"]["GearLvrPos_D_Actl"])
-      else:
-        gear = self.shifter_values.get(cp.vl["PowertrainData_10"]["TrnRng_D_Rq"])
-
-      ret.gearShifter = self.parse_gear_shifter(gear)
+     if self.CP.flags & FordFlags.CANFD:
+      gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
+     elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
+      if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
+       ret.gearShifter = GearShifter.drive
+     elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
+      ret.gearShifter = GearShifter.reverse
     elif self.CP.transmissionType == TransmissionType.manual:
-      ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
-      if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
-        ret.gearShifter = GearShifter.reverse
-      else:
-        ret.gearShifter = GearShifter.drive
+     ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
+     if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
+      ret.gearShifter = GearShifter.reverse
+     else:
+      ret.gearShifter = GearShifter.drive
 
     # safety
     ret.stockFcw = bool(cp_cam.vl["ACCDATA_3"]["FcwVisblWarn_B_Rq"])

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -88,14 +88,14 @@ class CarState(CarStateBase):
       elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
         if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
          ret.gearShifter = GearShifter.drive
-      elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
-        ret.gearShifter = GearShifter.reverse
+        elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
+         ret.gearShifter = GearShifter.reverse
     elif self.CP.transmissionType == TransmissionType.manual:
       ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
       if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
         ret.gearShifter = GearShifter.reverse
-     else:
-      ret.gearShifter = GearShifter.drive
+      else:
+        ret.gearShifter = GearShifter.drive
 
     # safety
     ret.stockFcw = bool(cp_cam.vl["ACCDATA_3"]["FcwVisblWarn_B_Rq"])

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -83,8 +83,10 @@ class CarState(CarStateBase):
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:
-      gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
-      ret.gearShifter = self.parse_gear_shifter(gear)
+      if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
+        ret.gearShifter = GearShifter.drive
+      elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
+        ret.gearShifter = GearShifter.reverse
     elif self.CP.transmissionType == TransmissionType.manual:
       ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
       if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -83,17 +83,17 @@ class CarState(CarStateBase):
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:
-     if self.CP.flags & FordFlags.CANFD:
-      gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
-     elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
-      if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
-       ret.gearShifter = GearShifter.drive
-     elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
-      ret.gearShifter = GearShifter.reverse
+      if self.CP.flags & FordFlags.CANFD:
+        gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
+      elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
+        if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
+         ret.gearShifter = GearShifter.drive
+      elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
+        ret.gearShifter = GearShifter.reverse
     elif self.CP.transmissionType == TransmissionType.manual:
-     ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
-     if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
-      ret.gearShifter = GearShifter.reverse
+      ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
+      if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
+        ret.gearShifter = GearShifter.reverse
      else:
       ret.gearShifter = GearShifter.drive
 

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -83,10 +83,14 @@ class CarState(CarStateBase):
 
     # gear
     if self.CP.transmissionType == TransmissionType.automatic:
-      if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
-        ret.gearShifter = GearShifter.drive
-      elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
-        ret.gearShifter = GearShifter.reverse
+      if self.CP.flags & FordFlags.CANFD:
+        gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
+      elif self.CP.flags & FordFlags.ALT_STEER_ANGLE:
+           gear = self.shifter_values.get(cp.vl["TransGearData"]["GearLvrPos_D_Actl"])
+      else:
+        gear = self.shifter_values.get(cp.vl["PowertrainData_10"]["TrnRng_D_Rq"])
+
+      ret.gearShifter = self.parse_gear_shifter(gear)
     elif self.CP.transmissionType == TransmissionType.manual:
       ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
       if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -164,6 +164,11 @@ class CAR(Platforms):
     [FordCarDocs("Ford Ranger 2024", "Adaptive Cruise Control with Lane Centering")],
     CarSpecs(mass=2000, wheelbase=3.27, steerRatio=17.0),
   )
+  Lincoln_nautilus = FordPlatformConfig(
+    [FordCarDocs("Lincoln nautilus 2018-21", "Adaptive Cruise Control with Lane Centering")],  
+    CarSpecs(mass=2050, steerRatio=19.3, wheelbase=3.824),
+    flags=FordFlags.ALT_STEER_ANGLE,
+  )
 
 
 # FW response contains a combined software and part number

--- a/selfdrive/car/torque_data/override.toml
+++ b/selfdrive/car/torque_data/override.toml
@@ -31,6 +31,7 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "FORD_F_150_LIGHTNING_MK1" = [nan, 1.5, nan]
 "FORD_MUSTANG_MACH_E_MK1" = [nan, 1.5, nan]
 "FORD_RANGER_MK2" = [nan, 1.5, nan]
+"LINCOLN_NAUTILUS" = [nan, 2.5, nan]
 ###
 
 # No steering wheel


### PR DESCRIPTION
in some Lincoln, Ford car have S Gear, but the official and  bluepilot can't recongnized it, it showed Gear not D, I had asked Qi helping revised it by the code like as follow:
 # gear
  if self.CP.transmissionType == TransmissionType.automatic:
if (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] in (3, 4, 5)):
ret.gearShifter = GearShifter.drive
elif (cp.vl["TransGearData"]["GearLvrPos_D_Actl"] == 1):
ret.gearShifter = GearShifter.reverse
elif self.CP.transmissionType == TransmissionType.manual:
ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
ret.gearShifter = GearShifter.reverse
else:
ret.gearShifter = GearShifter.drive

in the bluepilot 2.0, it work normal, but in the bluepilot 2.1, it showed Gear not D, and the system don't work.
The code in bluepilot 2.1 is:
 # gear
    if self.CP.transmissionType == TransmissionType.automatic:
      gear = self.shifter_values.get(cp.vl["Gear_Shift_by_Wire_FD1"]["TrnRng_D_RqGsm"])
      ret.gearShifter = self.parse_gear_shifter(gear)
    elif self.CP.transmissionType == TransmissionType.manual:
      ret.clutchPressed = cp.vl["Engine_Clutch_Data"]["CluPdlPos_Pc_Meas"] > 0
      if bool(cp.vl["BCM_Lamp_Stat_FD1"]["RvrseLghtOn_B_Stat"]):
        ret.gearShifter = GearShifter.reverse
      else:
        ret.gearShifter = GearShifter.drive