### PR TITLE
mici lead vehicle speed indication, and confidence ball for tizi (#43)

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -282,4 +282,5 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LC_PID_gain_UI", {PERSISTENT | BACKUP, FLOAT, "3.0"}},
     {"disable_BP_lat_UI", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"vbatt_pause_charging", {PERSISTENT | BACKUP, FLOAT, "11.8"}},
+    {"show_lead_speed", {PERSISTENT | BACKUP, BOOL, "1"}},
 };

--- a/selfdrive/ui/mici/layouts/settings/bluepilot.py
+++ b/selfdrive/ui/mici/layouts/settings/bluepilot.py
@@ -22,6 +22,7 @@ class BluePilotLayoutMici(NavWidget):
 
     # ******** Main Scroller ********
     self.show_hands_free_ui = BigParamControl("show hands-free ui", "send_hands_free_cluster_msg")
+    self.show_lead_vehicle = BigParamControl("show lead vehicle speed", "show_lead_speed")
     self.enable_human_turn_detection = BigParamControl("enable human turn detection", "enable_human_turn_detection")
     self.lane_change_factor_high = BigParamFloatControl("lane change factor high", "lane_change_factor_high", min=0.5, max=1.0)
     self.enable_lane_positioning = BigParamControl("enable lane positioning", "enable_lane_positioning", tint=rl.GREEN)
@@ -39,6 +40,7 @@ class BluePilotLayoutMici(NavWidget):
 
     self._scroller = Scroller([
       self.show_hands_free_ui,
+      self.show_lead_vehicle,
       self.enable_human_turn_detection,
       self.lane_change_factor_high,
       self.enable_lane_positioning,
@@ -55,6 +57,7 @@ class BluePilotLayoutMici(NavWidget):
     # Toggle lists
     self._refresh_toggles = (
       ("send_hands_free_cluster_msg", self.show_hands_free_ui),
+      ("show_lead_speed", self.show_lead_vehicle),
       ("enable_human_turn_detection", self.enable_human_turn_detection),
       ("enable_lane_positioning", self.enable_lane_positioning),
       ("enable_lane_full_mode", self.enable_lane_full_mode),

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -3,6 +3,7 @@ import numpy as np
 import pyray as rl
 from cereal import messaging, car, log
 from msgq.visionipc import VisionStreamType
+from openpilot.selfdrive.ui.mici.onroad.lead_vehicle import LeadVehicleRenderer
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.selfdrive.ui.mici.onroad import SIDE_PANEL_WIDTH
 from openpilot.selfdrive.ui.mici.onroad.alert_renderer import AlertRenderer
@@ -154,6 +155,7 @@ class AugmentedRoadView(CameraView):
     self._alert_renderer = AlertRenderer()
     self._driver_state_renderer = DriverStateRenderer()
     self._confidence_ball = ConfidenceBall()
+    self._lead_car = LeadVehicleRenderer()
     self._offroad_label = UnifiedLabel("start the car to\nuse sunnypilot", 54, FontWeight.DISPLAY,
                                        text_color=rl.Color(255, 255, 255, int(255 * 0.9)),
                                        alignment=rl.GuiTextAlignment.TEXT_ALIGN_CENTER,
@@ -227,9 +229,12 @@ class AugmentedRoadView(CameraView):
     self._hud_renderer.set_can_draw_top_icons(alert_to_render is None)
     self._hud_renderer.set_wheel_critical_icon(alert_to_render is not None and not not_animating_out and
                                                alert_to_render.visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired)
+    self._lead_car.render(self._content_rect)
+
     # TODO: have alert renderer draw offroad mici label below
     if ui_state.started:
       self._alert_renderer.render(self._content_rect)
+
     self._hud_renderer.render(self._content_rect)
 
     # Draw fake rounded border

--- a/selfdrive/ui/mici/onroad/confidence_ball.py
+++ b/selfdrive/ui/mici/onroad/confidence_ball.py
@@ -24,11 +24,12 @@ def draw_circle_gradient(center_x: float, center_y: float, radius: int,
 
 
 class ConfidenceBall(Widget, ConfidenceBallSP):
-  def __init__(self, demo: bool = False):
+  def __init__(self, demo: bool = False, radius: float=24):
     Widget.__init__(self)
     ConfidenceBallSP.__init__(self)
     self._demo = demo
     self._confidence_filter = FirstOrderFilter(-0.5, 0.5, 1 / gui_app.target_fps)
+    self._status_dot_radius = radius
 
   def update_filter(self, value: float):
     self._confidence_filter.update(value)
@@ -54,8 +55,7 @@ class ConfidenceBall(Widget, ConfidenceBallSP):
       self.rect.height,
     )
 
-    status_dot_radius = 24
-    dot_height = (1 - self._confidence_filter.x) * (content_rect.height - 2 * status_dot_radius) + status_dot_radius
+    dot_height = (1 - self._confidence_filter.x) * (content_rect.height - 2 * self._status_dot_radius) + self._status_dot_radius
     dot_height = self._rect.y + dot_height
 
     # confidence zones
@@ -81,6 +81,6 @@ class ConfidenceBall(Widget, ConfidenceBallSP):
       top_dot_color = rl.Color(50, 50, 50, 255)
       bottom_dot_color = rl.Color(13, 13, 13, 255)
 
-    draw_circle_gradient(content_rect.x + content_rect.width - status_dot_radius,
-                         dot_height, status_dot_radius,
+    draw_circle_gradient(content_rect.x + content_rect.width - self._status_dot_radius,
+                         dot_height, self._status_dot_radius,
                          top_dot_color, bottom_dot_color)

--- a/selfdrive/ui/mici/onroad/lead_vehicle.py
+++ b/selfdrive/ui/mici/onroad/lead_vehicle.py
@@ -1,0 +1,78 @@
+import pyray as rl
+import numpy as np
+from openpilot.common.constants import CV
+from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.multilang import tr
+from openpilot.system.ui.lib.text_measure import measure_text_cached
+from openpilot.system.ui.widgets import Widget
+from openpilot.common.params import Params
+
+FONT_SIZE = 68
+UNIT_FONT_SIZE = 24
+WIDTH = 80
+COLOR_DELTA_MS = 4.5  # ~ 10MPH
+
+class LeadVehicleRenderer(Widget):
+  def __init__(self):
+    super().__init__()
+    self.speed: float = 0.0
+    self._font_bold: rl.Font = gui_app.font(FontWeight.BOLD)
+    self._color = np.array([255, 255, 255], dtype=float)
+    self._slower_color = np.array([255,  0,  0], dtype=float)
+    self._faster_color = np.array([0, 255,  0], dtype=float)
+    self._font_color: rl.Color = rl.Color(255, 255, 255, 180)
+    self._car_state = None
+    self._should_render = False
+
+    self.params = Params()
+
+  def _update_state(self):
+     self._should_render = self.params.get_bool("show_lead_speed")
+
+  def _render(self, rect: rl.Rectangle) -> None:
+    """Draw the first lead vehicle speed and unit."""
+    if not self._should_render:
+      return
+
+    sm = ui_state.sm
+    self._car_state = sm['carState']
+    self._radar_state = sm['radarState'] if sm.valid['radarState'] else None
+    lead_one = self._radar_state.leadOne if self._radar_state else None
+    has_lead_one = lead_one.status if lead_one else False
+    render_lead_indicator = self._radar_state is not None and has_lead_one
+    if not render_lead_indicator:
+      return
+
+    speed_conversion = CV.MS_TO_KPH if ui_state.is_metric else CV.MS_TO_MPH
+    speed_delta = lead_one.vRel * speed_conversion
+    self.speed = max(0.0, self._car_state.vEgoCluster * speed_conversion + speed_delta)
+
+
+    v_delta = np.clip(lead_one.vRel, -COLOR_DELTA_MS, COLOR_DELTA_MS)
+    if v_delta <= 0:
+        t = (v_delta + COLOR_DELTA_MS) / COLOR_DELTA_MS
+        result = (1 - t) * self._slower_color + t * self._color
+    else:
+        t = v_delta / COLOR_DELTA_MS
+        result = (1 - t) * self._color + t * self._faster_color
+
+    color = result.astype(int)
+    self._font_color = rl.Color(color[0], color[1], color[2], 180)
+
+    speed_text = str(round(self.speed))
+    speed_text_size = measure_text_cached(self._font_bold, speed_text, FONT_SIZE)
+    pos_x = rect.x + rect.width - WIDTH - 5
+    speed_pos = rl.Vector2(pos_x + ((WIDTH - speed_text_size.x) / 2), rect.y + rect.height * 0.66 - speed_text_size.y / 2)
+    rl.draw_text_ex(self._font_bold, speed_text, speed_pos, FONT_SIZE, 0, self._font_color)
+
+    unit_text = tr("km/h") if ui_state.is_metric else tr("mph")
+    unit_text_size = measure_text_cached(self._font_bold, unit_text, UNIT_FONT_SIZE)
+    unit_pos = rl.Vector2(pos_x + WIDTH / 2 - unit_text_size.x / 2, speed_pos.y + speed_text_size.y - 15)
+    rl.draw_text_ex(self._font_bold, unit_text, unit_pos, UNIT_FONT_SIZE, 0, self._font_color)
+
+    size = 20
+    x = pos_x + WIDTH / 2
+    y = speed_pos.y - 10
+    chevron = [(x + (size * 1.25), y + size), (x, y), (x - (size * 1.25), y + size)]
+    rl.draw_triangle_fan(chevron, len(chevron), rl.Color(201, 34, 49, 150))

--- a/selfdrive/ui/mici/onroad/torque_bar.py
+++ b/selfdrive/ui/mici/onroad/torque_bar.py
@@ -2,7 +2,6 @@ import math
 import time
 from functools import wraps
 from collections import OrderedDict
-import cereal.messaging as messaging
 
 import numpy as np
 import pyray as rl
@@ -155,21 +154,11 @@ class TorqueBar(Widget):
     self._torque_line_height_min=line_height_min
     self._torque_line_height_max=line_height_max
 
-    # self._demo_torque = 0.0
-    # self._demo_increment = 0.03
-
   def update_filter(self, value: float):
     """Update the torque filter value (for demo mode)."""
     self._torque_filter.update(value)
 
   def _update_state(self):
-    # if (self._torque_filter.x > 1.1):
-    #   self._demo_increment = -0.03
-    # elif (self._torque_filter.x < -1.1):
-    #   self._demo_increment = 0.03
-    # self._demo_torque += self._demo_increment
-    # self.update_filter(self._demo_torque)
-
     if self._demo:
       return
 

--- a/selfdrive/ui/onroad/augmented_road_view.py
+++ b/selfdrive/ui/onroad/augmented_road_view.py
@@ -13,6 +13,7 @@ from openpilot.selfdrive.ui.onroad.cameraview import CameraView
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.common.transformations.camera import DEVICE_CAMERAS, DeviceCameraConfig, view_frame_from_device_frame
 from openpilot.common.transformations.orientation import rot_from_euler
+from openpilot.selfdrive.ui.mici.onroad.confidence_ball import ConfidenceBall
 
 if gui_app.sunnypilot_ui():
   from openpilot.selfdrive.ui.sunnypilot.onroad.hud_renderer import HudRendererSP as HudRenderer
@@ -55,6 +56,7 @@ class AugmentedRoadView(CameraView):
     self._hud_renderer = HudRenderer()
     self.alert_renderer = AlertRenderer()
     self.driver_state_renderer = DriverStateRenderer()
+    self._confidence_ball = ConfidenceBall(radius=50)
 
     # debug
     self._pm = messaging.PubMaster(['uiDebug'])
@@ -71,12 +73,13 @@ class AugmentedRoadView(CameraView):
     self._update_calibration()
 
     # Create inner content area with border padding
-    self._content_rect = rl.Rectangle(
-      rect.x + UI_BORDER_SIZE,
-      rect.y + UI_BORDER_SIZE,
-      rect.width - 2 * UI_BORDER_SIZE,
-      rect.height - 2 * UI_BORDER_SIZE,
-    )
+    # self._content_rect = rl.Rectangle(
+    #   rect.x + UI_BORDER_SIZE,
+    #   rect.y + UI_BORDER_SIZE,
+    #   rect.width - 2 * UI_BORDER_SIZE,
+    #   rect.height - 2 * UI_BORDER_SIZE,
+    # )
+    self._content_rect = rect
 
     # Enable scissor mode to clip all rendering within content rectangle boundaries
     # This creates a rendering viewport that prevents graphics from drawing outside the border
@@ -91,6 +94,7 @@ class AugmentedRoadView(CameraView):
     super()._render(rect)
 
     # Draw all UI overlays
+    self._confidence_ball.render(self.rect)
     self.model_renderer.render(self._content_rect)
     self._hud_renderer.render(self._content_rect)
     self.alert_renderer.render(self._content_rect)
@@ -103,7 +107,7 @@ class AugmentedRoadView(CameraView):
     rl.end_scissor_mode()
 
     # Draw colored border based on driving state
-    self._draw_border(rect)
+    #self._draw_border(rect)
 
     # publish uiDebug
     msg = messaging.new_message('uiDebug')

--- a/selfdrive/ui/onroad/cameraview.py
+++ b/selfdrive/ui/onroad/cameraview.py
@@ -214,8 +214,8 @@ class CameraView(Widget):
     x_offset = rect.x + (rect.width - scale_x) / 2
     y_offset = rect.y + (rect.height - scale_y) / 2
 
-    x_offset += transform[0, 2] * rect.width / 2
-    y_offset += transform[1, 2] * rect.height / 2
+    # x_offset += transform[0, 2] * rect.width / 2
+    # y_offset += transform[1, 2] * rect.height / 2
 
     dst_rect = rl.Rectangle(x_offset, y_offset, scale_x, scale_y)
 

--- a/selfdrive/ui/onroad/exp_button.py
+++ b/selfdrive/ui/onroad/exp_button.py
@@ -49,7 +49,7 @@ class ExpButton(Widget):
     self._white_color.a = 180 if self.is_pressed or not self._engageable else 255
 
     texture = self._txt_exp if self._held_or_actual_mode() else self._txt_wheel
-    rl.draw_circle(center_x, center_y, self._rect.width / 2, self._black_bg)
+    #rl.draw_circle(center_x, center_y, self._rect.width / 2, self._black_bg)
     rl.draw_texture(texture, center_x - texture.width // 2, center_y - texture.height // 2, self._white_color)
 
   def _held_or_actual_mode(self):

--- a/selfdrive/ui/sunnypilot/mici/onroad/confidence_ball.py
+++ b/selfdrive/ui/sunnypilot/mici/onroad/confidence_ball.py
@@ -4,9 +4,16 @@ Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
 This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
-from openpilot.selfdrive.ui.onroad.augmented_road_view import BORDER_COLORS
+import pyray as rl
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 
+BORDER_COLORS = {
+  UIStatus.DISENGAGED: rl.Color(0x12, 0x28, 0x39, 0xFF),  # Blue for disengaged state
+  UIStatus.OVERRIDE: rl.Color(0x89, 0x92, 0x8D, 0xFF),  # Gray for override state
+  UIStatus.ENGAGED: rl.Color(0x16, 0x7F, 0x40, 0xFF),  # Green for engaged state
+  UIStatus.LAT_ONLY: rl.Color(0x00, 0xC8, 0xC8, 0xFF),  # Cyan for lateral-only state
+  UIStatus.LONG_ONLY: rl.Color(0x96, 0x1C, 0xA8, 0xFF),  # Purple for longitudinal-only state
+}
 
 class ConfidenceBallSP:
   @staticmethod

--- a/sunnypilot/sunnylink/params_metadata.json
+++ b/sunnypilot/sunnylink/params_metadata.json
@@ -1202,5 +1202,9 @@
     "max": 14.0,
     "step": 0.1,
     "description": "Voltage at which BluePilot will shutdown and avoid draining the car battery."
+  },
+  "show_lead_speed": {
+    "title": "BluePilot: Show Lead Vehicle Speed",
+    "description": "Show the lead vehicle's speed in the UI."
   }
 }


### PR DESCRIPTION
* mici lead vehicle speed

* cleanup

* cleanup

* debugging

* confidence ball for tizi

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

