### PR TITLE
Modifed OP ACC to enhance coasting, and also option to disable downhill assist within OP, becasue many ford vehicles handle it nativly.

### DIFF
--- a/bluepilot/params/params.json
+++ b/bluepilot/params/params.json
@@ -27,6 +27,15 @@
       "enabled": true
     },
     {
+      "name": "FordPrefDisableDownhillCompUI",
+      "default": false,
+      "type": "bool",
+      "flags": ["PERSISTENT", "BACKUP"],
+      "ccProp": "disable_downhill_comp_UI",
+      "create_default": true,
+      "enabled": true
+    },
+    {
       "name": "FordPrefHumanTurnDetectionEnable",
       "default": true,
       "type": "bool",

--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -466,6 +466,12 @@ struct CustomReserved12 @0x9ccdc8676701b412 {
 
 struct ControllerStateBP @0xcd96dafb67a082d0 {
     lateralUncertainty @0 :Float32; #BluePilot
+    # Long-control debug: which path (BP vs stock) and why
+    disableBpLongUI @1 :Bool;
+    leadPresent @2 :Bool;
+    vLeadMph @3 :Float32;
+    bpSpeedAllow @4 :Bool;
+    applyBpLong @5 :Bool;
 }
 
 struct CarStateBP @0xb057204d7deadf3f {

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -286,6 +286,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LC_PID_gain_UI", {PERSISTENT | BACKUP, FLOAT, "3.0"}},
     {"disable_BP_lat_UI", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"disable_BP_long_UI", {PERSISTENT | BACKUP, BOOL, "0"}},
+    {"disable_downhill_comp_UI", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"FordFollowingGasROC", {PERSISTENT | BACKUP, FLOAT, "0.05"}},
     {"FordFollowingAccelROC", {PERSISTENT | BACKUP, FLOAT, "0.025"}},
     {"vbatt_pause_charging", {PERSISTENT | BACKUP, FLOAT, "11.8"}},

--- a/opendbc_repo/opendbc/car/ford/LONG_BRAKE_ACTUATE_ANALYSIS.md
+++ b/opendbc_repo/opendbc/car/ford/LONG_BRAKE_ACTUATE_ANALYSIS.md
@@ -1,0 +1,150 @@
+# Long control: why brake_actuate can be true with positive gas/accel
+
+## Your scenario (summary)
+
+- `disable_BP_long_UI` = False (BP long intended on)
+- vego ≈ 34 m/s, dRel = 0 (no lead)
+- gas = 0.25, accel = 0.2440 (both positive)
+- orientationNED[1] = -0.03 (downhill)
+- **brake_actuate = true** ← unexpected
+
+## How brake_actuate is set
+
+There are two sources of `brake_actuate` in the Ford car controller:
+
+1. **Stock path:** `op_brake_actuate` (pitch‑compensated stock accel + hysteresis)
+2. **BP path:** `bp_brake_actuate` (from `bp_accel` when `apply_bp_long` is True)
+
+You only ever get **positive output accel and brake_actuate true** when the **stock path** is used. When the BP path is used, `brake_actuate = bp_brake_actuate` and `accel = bp_accel`; brake is only set when `bp_accel < brake_actuate_target (-0.14)`, so output accel would be negative in that same frame.
+
+So in your log, the frame where brake_actuate is true is almost certainly using the **stock** path (`apply_bp_long` False), and the brake flag comes from **op_brake_actuate**.
+
+---
+
+## 1. Stock path: op_brake_actuate (pitch + hysteresis)
+
+Relevant code (around 792–801):
+
+```python
+# Pitch compensation: PCM interprets accel in vehicle frame; we compensate for brake bits
+accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY  # NED[1] = pitch, rad
+accel_pitch_compensated = op_accel + accel_due_to_pitch
+
+op_brake_actuate = self.op_brake_actuate_last
+if accel_pitch_compensated > self.brake_actuate_release:   # -0.06
+  op_brake_actuate = False
+elif accel_pitch_compensated < self.brake_actuate_target:   # -0.14
+  op_brake_actuate = True
+# else: keep previous (hysteresis between -0.14 and -0.06)
+```
+
+Constants:
+
+- `brake_actuate_target` = -0.14  
+- `brake_actuate_release` = -0.06  
+
+So:
+
+- Brake **on** when `accel_pitch_compensated < -0.14`
+- Brake **off** when `accel_pitch_compensated > -0.06`
+- In between, **keep** `op_brake_actuate_last` (hysteresis)
+
+With your numbers:
+
+- `accel_due_to_pitch = sin(-0.03) * 9.81 ≈ -0.294 m/s²`
+- If **op_accel** (the value used in this block) were **0.244**:
+  - `accel_pitch_compensated = 0.244 - 0.294 = -0.05` → **> -0.06** → brake would be **released** (False).
+
+So with “accel = 0.244” and pitch -0.03, the **current frame** would not set brake **unless** the accel value used here is **not** 0.244. That leads to the next point: the accel that matters is **op_accel**, which can be **rate‑limited** below actuators.accel.
+
+---
+
+## 2. Rate limit on op_accel (most likely cause)
+
+Stock accel is rate‑limited **only on the way down** (around 779–784):
+
+```python
+op_accel = actuators.accel
+if CC.longActive:
+  op_accel = apply_creep_compensation(op_accel, CS.out.vEgo)
+  op_accel = max(op_accel, self.accel - (3.5 * CarControllerParams.ACC_CONTROL_STEP * DT_CTRL))
+```
+
+- `ACC_CONTROL_STEP = 2`, `DT_CTRL = 0.01` → max drop per ACC frame = **3.5 * 2 * 0.01 = 0.07 m/s²** (ACC runs at 50 Hz).
+
+So if **last frame** `self.accel` was 0.24, this frame **op_accel** can be no lower than 0.24 - 0.07 = **0.17**. If controlsd requested 0.244, you can still have **op_accel = 0.17** in the controller.
+
+Then:
+
+- `accel_pitch_compensated = 0.17 - 0.294 = -0.124`
+- -0.124 is **between -0.14 and -0.06** → hysteresis: **op_brake_actuate is unchanged**.
+- If the previous frame had **op_brake_actuate = True** (e.g. from an earlier more negative accel or steeper pitch), it **stays True** this frame even though requested accel is positive.
+
+Output in that case:
+
+- `accel = op_accel = 0.17` (not 0.244)
+- `brake_actuate = op_brake_actuate = True`
+- Then gas is forced off: `if brake_actuate: gas = INACTIVE_GAS`
+
+So the scenario that fits your log is:
+
+1. **apply_bp_long** is False (so stock path is used; see below why).
+2. **op_accel** is **rate‑limited** below actuators.accel (e.g. 0.17 instead of 0.244).
+3. **accel_pitch_compensated** lands in the hysteresis band and **op_brake_actuate** stays True from the previous frame.
+4. The “accel” and “gas” you’re logging may be **actuators.accel / actuators.gas** (0.244, 0.25) from **carControl**, not the **car controller output** (0.17 and then gas cleared). So you see positive gas/accel in the log while the car is actually sending brake and reduced accel.
+
+---
+
+## 3. When is the stock path used? (apply_bp_long False)
+
+BP long is only used when **all** of these hold (around 937–938):
+
+```python
+apply_bp_long = (
+  self.disable_BP_long_UI == False
+  and self.bpSpeedAllow
+  and gasPressed == False
+  and brakePressed == False
+  and (lead is None or v_lead_mph > 40.0)
+)
+```
+
+So even with **disable_BP_long_UI = False**, the **stock** path is used if:
+
+- **bpSpeedAllow** is False (e.g. vego &lt; 45 mph, or you’re in the 45–50 mph deadband and it hasn’t been set True yet),
+- **gasPressed** or **brakePressed** is True,
+- or there **is** a lead with **v_lead_mph ≤ 40**.
+
+If the UI says “BP long on” but you’re in one of these cases, the controller will use stock logic and **op_brake_actuate**; the rate limit + pitch + hysteresis then explain brake staying on with “positive” requested accel.
+
+---
+
+## 4. disable_BP_long_UI: is it read correctly?
+
+- **Where it’s read:** `_update_params()` (around 293):  
+  `self.disable_BP_long_UI = self.params.get_bool("disable_BP_long_UI")`
+- **When:** `_update_params()` is called from `update()` every control cycle (around 374).
+- So the value is refreshed every frame from Params. If the UI writes the param when you toggle, the controller should see it shortly after. A one‑frame delay is possible; a persistent mismatch (UI shows False but code always behaves as True) would point to param name or write path, not “never read”.
+
+---
+
+## 5. Checks you can do in your logs
+
+1. **Which accel/gas are you logging?**
+   - **carControl.actuators.accel / .gas** = controlsd request (e.g. 0.244, 0.25).
+   - **Car controller output** = what gets sent on CAN (and after `if brake_actuate: gas = INACTIVE_GAS`). If you log `self.accel` / `self.gas` from the controller, you’d see 0.17 and 0 in the brake frame.
+2. **Confirm stock path in the brake frame:**  
+   Log or infer **apply_bp_long** (or at least: **bpSpeedAllow**, **gasPressed**, **brakePressed**, and lead presence/speed). If apply_bp_long is False in that frame, brake is from **op_brake_actuate**.
+3. **Pitch and rate limit:**  
+   Log **op_accel** and **accel_pitch_compensated** (or add them for debugging). You should see op_accel pulled down by the 0.07 m/s² rate limit and accel_pitch_compensated in the -0.14 to -0.06 band when brake stays on with “positive” requested accel.
+4. **Hysteresis:**  
+   Log **op_brake_actuate_last** at the start of the frame; if it’s True and accel_pitch_compensated is in (-0.14, -0.06), brake will stay True.
+
+---
+
+## 6. Summary
+
+- **brake_actuate** can be true with “positive” gas/accel only when the **stock** path is used.
+- **op_brake_actuate** is driven by **accel_pitch_compensated** and **hysteresis** (-0.14 / -0.06).
+- **Rate limiting** can make **op_accel** lower than actuators.accel (e.g. 0.17 vs 0.244); with your pitch that puts **accel_pitch_compensated** in the hysteresis band so **op_brake_actuate** can **stay** True from the previous frame.
+- So the most likely explanation is: **apply_bp_long** False in that frame, **op_accel** rate‑limited, **accel_pitch_compensated** in (-0.14, -0.06), and **op_brake_actuate_last** True → brake stays on while the **requested** (actuators) accel/gas are positive. Verifying in the log which accel/gas you’re looking at and adding the suggested signals will confirm it.

--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -21,17 +21,6 @@ from opendbc.sunnypilot.car.ford.icbm import IntelligentCruiseButtonManagementIn
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 
-
-def _get_T_FOLLOW(personality):
-  """Match long_mpc.get_T_FOLLOW: follow time (s) from driving personality (relaxed/standard/aggressive)."""
-  if personality == log.LongitudinalPersonality.relaxed:
-    return 1.75
-  if personality == log.LongitudinalPersonality.standard:
-    return 1.45
-  if personality == log.LongitudinalPersonality.aggressive:
-    return 1.25
-  return 1.45  # default standard if unknown
-
 def index_function(idx, max_val=192, max_idx=32):
   return (max_val) * ((idx/max_idx)**2)
 
@@ -156,6 +145,13 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
     self.bp_gas_last = 0.0
     self.bp_accel_last = 0.0
     self.bpSpeedAllow = False # initialize to false
+
+    # Long-control debug for controllerStateBP (which path BP vs stock and why)
+    self.bp_long_debug_disable_bp_long_ui = False
+    self.bp_long_debug_lead_present = False
+    self.bp_long_debug_v_lead_mph = 0.0
+    self.bp_long_debug_bp_speed_allow = False
+    self.bp_long_debug_apply_bp_long = False
 
     # Long Control Variables
     self.MAX_URBAN_SPEED_MPH = 45.0
@@ -830,6 +826,27 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
         self.bpSpeedAllow = True
       if bpSpeedTooSlow:
         self.bpSpeedAllow = False
+
+      # Long-control debug for controllerStateBP (log which path and why)
+      lead_debug = None
+      v_lead_mph_debug = 0.0
+      if self.sm.valid.get('radarState', False):
+        rs = self.sm['radarState']
+        lead_debug = getattr(rs, 'leadOne', None)
+        if lead_debug and getattr(lead_debug, 'status', False):
+          v_lead_mph_debug = float(getattr(lead_debug, 'vLead', 0)) * 2.23694
+      gasPressed_debug = CS.out.gasPressed
+      brakePressed_debug = CS.out.brakePressed
+      apply_bp_long_debug = (
+        self.disable_BP_long_UI == False and self.bpSpeedAllow
+        and not gasPressed_debug and not brakePressed_debug
+        and (lead_debug is None or v_lead_mph_debug > 40.0)
+      )
+      self.bp_long_debug_disable_bp_long_ui = self.disable_BP_long_UI
+      self.bp_long_debug_lead_present = (lead_debug is not None)
+      self.bp_long_debug_v_lead_mph = v_lead_mph_debug
+      self.bp_long_debug_bp_speed_allow = self.bpSpeedAllow
+      self.bp_long_debug_apply_bp_long = apply_bp_long_debug
 
       # BluePilot longitudinal: gas limits when following + rate-limited accel/brake to avoid stomping.
       if not self.disable_BP_long_UI:

--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -807,9 +807,9 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
 
       accel_pitch_compensated = op_accel + accel_due_to_pitch
       op_brake_actuate = self.op_brake_actuate_last
-      if accel_pitch_compensated > 0.3 or not CC.longActive:
+      if accel_pitch_compensated > self.brake_actuate_release or not CC.longActive:
         op_brake_actuate = False
-      elif accel_pitch_compensated < 0.0:
+      elif accel_pitch_compensated < self.brake_actuate_target:
         op_brake_actuate = True
       # else: keep op_brake_actuate (hysteresis between 0 and 0.3)
 

--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -163,6 +163,7 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
     self.precharge_actuate_target = -0.12 # at what accel limit do we engage precharge
     self.precharge_actuate_release = -0.06 # at what accel limit do we release precharge
     self.op_brake_actuate_last = False # init the value for our hysteresis
+    self.disable_downhill_comp_UI = True #flag to disable downhill pitch compensation
 
     # # Curvature variables
     self.curvature_lookup_time = 0.42 #from lagd
@@ -287,6 +288,7 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
     self.LC_PID_gain_UI = float(self.params.get("LC_PID_gain_UI", return_default=True))
     # Ford long: bypass BP longitudinal toggle (gas/accel ROC use __init__ defaults only)
     self.disable_BP_long_UI = self.params.get_bool("disable_BP_long_UI")
+    self.disable_downhill_comp_UI = self.params.get_bool("disable_downhill_comp_UI")
 
   def handle_post_lane_change_transition(self, path_angle, path_offset, desired_curvature_rate):
     """
@@ -800,6 +802,11 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
       accel_due_to_pitch = 0.0
       if len(CC.orientationNED) == 3:
         accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY
+
+      # some ford vehicles have downhill compensation built in, adding in accel_due_to_pitch is double dipping, creating harsh braking downhill
+      if self.disable_downhill_comp_UI:
+          if accel_due_to_pitch < 0:
+              accel_due_to_pitch = 0
 
       accel_pitch_compensated = op_accel + accel_due_to_pitch
       op_brake_actuate = self.op_brake_actuate_last

--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -828,22 +828,25 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
         self.bpSpeedAllow = False
 
       # Long-control debug for controllerStateBP (log which path and why)
+      # RadarState.leadOne.status: 0 = no lead, 1 = lead
       lead_debug = None
+      has_lead = False
       v_lead_mph_debug = 0.0
       if self.sm.valid.get('radarState', False):
         rs = self.sm['radarState']
         lead_debug = getattr(rs, 'leadOne', None)
-        if lead_debug and getattr(lead_debug, 'status', False):
+        if lead_debug is not None and getattr(lead_debug, 'status', 0) == 1:
+          has_lead = True
           v_lead_mph_debug = float(getattr(lead_debug, 'vLead', 0)) * 2.23694
       gasPressed_debug = CS.out.gasPressed
       brakePressed_debug = CS.out.brakePressed
       apply_bp_long_debug = (
         self.disable_BP_long_UI == False and self.bpSpeedAllow
         and not gasPressed_debug and not brakePressed_debug
-        and (lead_debug is None or v_lead_mph_debug > 40.0)
+        and (not has_lead or v_lead_mph_debug > 40.0)
       )
       self.bp_long_debug_disable_bp_long_ui = self.disable_BP_long_UI
-      self.bp_long_debug_lead_present = (lead_debug is not None)
+      self.bp_long_debug_lead_present = has_lead
       self.bp_long_debug_v_lead_mph = v_lead_mph_debug
       self.bp_long_debug_bp_speed_allow = self.bpSpeedAllow
       self.bp_long_debug_apply_bp_long = apply_bp_long_debug
@@ -851,7 +854,7 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
       # BluePilot longitudinal: gas limits when following + rate-limited accel/brake to avoid stomping.
       if not self.disable_BP_long_UI:
 
-        # Lead time (s) and lead state
+        # Lead time (s) and lead state. leadOne.status: 0 = no lead, 1 = lead.
         v_ego = max(CS.out.vEgo, 0.5)
         lead_time_sec = 999.0  # no lead: treat as far
         lead = None
@@ -860,7 +863,9 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
         if self.sm.valid.get('radarState', False):
           rs = self.sm['radarState']
           lead = getattr(rs, 'leadOne', None)
-          if lead and getattr(lead, 'status', False):
+          if lead is not None and getattr(lead, 'status', 0) != 1:
+            lead = None
+          if lead:
             d_rel = float(getattr(lead, 'dRel', 0))
             v_rel = float(getattr(lead, 'vRel', 0))
             v_lead = float(getattr(lead, 'vLead', 0))  # m/s; schema is vLead (camelCase)
@@ -873,7 +878,9 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
         if self.sm.valid.get('radarState', False):
           rs = self.sm['radarState']
           lead = getattr(rs, 'leadOne', None)
-          if lead and getattr(lead, 'status', False):
+          if lead is not None and getattr(lead, 'status', 0) != 1:
+            lead = None
+          if lead:
             d_rel = float(getattr(lead, 'dRel', 0))
             v_rel = float(getattr(lead, 'vRel', 0))
             if d_rel > 0 and v_rel < 0:
@@ -927,6 +934,14 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
           min_follow_gas = op_gas
           max_follow_accel = op_accel
           min_follow_accel = op_accel
+
+        # limits with no lead
+        if lead == 0:
+          max_follow_gas = op_gas
+          min_follow_gas = op_gas
+          max_follow_accel = 0
+          min_follow_accel = 0
+
 
         # apply our bp gas and accel targets
         bp_gas = clip(op_gas, min_follow_gas, max_follow_gas)

--- a/opendbc_repo/opendbc/car/structs.py
+++ b/opendbc_repo/opendbc/car/structs.py
@@ -174,3 +174,8 @@ class CarStateSP:
 @auto_dataclass
 class ControllerStateBP:
   lateralUncertainty: float = auto_field()
+  disableBpLongUI: bool = auto_field()
+  leadPresent: bool = auto_field()
+  vLeadMph: float = auto_field()
+  bpSpeedAllow: bool = auto_field()
+  applyBpLong: bool = auto_field()

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -294,6 +294,11 @@ class Car:
     if hasattr(self.CI.CC, "lateralUncertainty"):
       cs_bp = structs.ControllerStateBP()
       cs_bp.lateralUncertainty = self.CI.CC.lateralUncertainty
+      cs_bp.disableBpLongUI = getattr(self.CI.CC, "bp_long_debug_disable_bp_long_ui", False)
+      cs_bp.leadPresent = getattr(self.CI.CC, "bp_long_debug_lead_present", False)
+      cs_bp.vLeadMph = getattr(self.CI.CC, "bp_long_debug_v_lead_mph", 0.0)
+      cs_bp.bpSpeedAllow = getattr(self.CI.CC, "bp_long_debug_bp_speed_allow", False)
+      cs_bp.applyBpLong = getattr(self.CI.CC, "bp_long_debug_apply_bp_long", False)
       cs_bp_capnp = convert_to_capnp(cs_bp)
       cs_bp_send = messaging.new_message('controllerStateBP')
       cs_bp_send.valid = True

--- a/selfdrive/ui/bp/layouts/settings/bluepilot.py
+++ b/selfdrive/ui/bp/layouts/settings/bluepilot.py
@@ -50,6 +50,7 @@ class BluePilotLayout(Widget):
       ("custom_profile", self._custom_profile),
       ("disable_BP_lat_UI", self._disable_BP_lat),
       ("disable_BP_long_UI", self._disable_BP_long),
+      ("disable_downhill_comp_UI", self._disable_dowhill_comp),
       ("BPUIDebugLog", self._ui_debug_log),
     )
 
@@ -330,6 +331,15 @@ class BluePilotLayout(Widget):
       icon="chffr_wheel.png"
     )
 
+    # Disable downhill compensation toggle
+    self._disable_dowhill_comp = toggle_item(
+      lambda: tr("Disable Downhill Compensation"),
+      lambda: tr("Disable pitch-based brake/gas compensation when going downhill."),
+      initial_state=self._params.get_bool("disable_downhill_comp_UI"),
+      callback=lambda state: self._toggle_callback(state, "disable_downhill_comp_UI"),
+      icon="chffr_wheel.png"
+    )
+
     # Preferred WiFi Network selector
     self._preferred_network_action = ButtonAction(lambda: tr("SELECT"))
     self._preferred_network_action.set_value(lambda: self._get_preferred_network_display())
@@ -365,6 +375,7 @@ class BluePilotLayout(Widget):
       self._vbatt_pause_charging,
       self._disable_BP_lat,
       self._disable_BP_long,
+      self._disable_dowhill_comp,
       self._preferred_network_btn,
       self._ui_debug_log,
     ]

--- a/selfdrive/ui/bp/mici/layouts/settings/bluepilot.py
+++ b/selfdrive/ui/bp/mici/layouts/settings/bluepilot.py
@@ -40,6 +40,7 @@ class BluePilotLayoutMici(NavWidget):
     self.hide_border = BigParamControlBP("hide screen border", "mici_hide_onroad_border")
     self.disable_BP_lat = BigParamControlBP("disable BP lateral control", "disable_BP_lat_UI")
     self.disable_BP_long = BigParamControlBP("bypass BP longitudinal control", "disable_BP_long_UI")
+    self.disable_dowhill_comp = BigParamControlBP("disable downhill compensation", "disable_downhill_comp_UI")
     self.ui_debug_log = BigParamControlBP("ui debug logging", "BPUIDebugLog")
     self.vbatt_pause_charging = BigParamFloatControl("12V battery limit", "vbatt_pause_charging", min=11.0, max=14.0, step=0.1)
 
@@ -84,6 +85,7 @@ class BluePilotLayoutMici(NavWidget):
       self.vbatt_pause_charging,
       self.disable_BP_lat,
       self.disable_BP_long,
+      self.disable_dowhill_comp,
       self.ui_debug_log,
     ], snap_items=False)
 
@@ -101,6 +103,7 @@ class BluePilotLayoutMici(NavWidget):
       ("custom_profile", self.custom_profile),
       ("disable_BP_lat_UI", self.disable_BP_lat),
       ("disable_BP_long_UI", self.disable_BP_long),
+      ("disable_downhill_comp_UI", self.disable_dowhill_comp),
       ("BPAnimateSteeringWheel", self.animate_steering_wheel),
       ("BPUIDebugLog", self.ui_debug_log),
       ("mici_hide_onroad_fade", self.hide_fade),


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/opcar/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

