### PR TITLE
fix stale lock

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -83,6 +83,12 @@ function launch {
   # start manager
   cd system/manager
   if [ ! -f $DIR/prebuilt ]; then
+    # BluePilot - Remove stale scons lock if it exists
+    if [ -f /data/scons_cache/config.lock ]; then
+      rm -f /data/scons_cache/config.lock
+    fi
+    # BluePilot - Remove stale scons lock if it exists
+
     ./build.py
   fi
   ./manager.py


### PR DESCRIPTION
**Description**

If the comma boots and a lock file is left behind it will never compile.. It is dangerous to delete this file once a compile may have started, but right at launch, before the first compile is a very small window that is safe.

**Verification**
On Device (3x)

