### PR TITLE
offline mode: use RFC 2606 .invalid hosts instead of imoffline.net

### DIFF
--- a/bluepilot/backend_switch.py
+++ b/bluepilot/backend_switch.py
@@ -44,7 +44,7 @@ BACKEND_LABELS = {
 PAIRING_HOST = {
   BACKEND_COMMA: "connect.comma.ai",
   BACKEND_KONIK: "stable.konik.ai",
-  BACKEND_OFFLINE: "imoffline.net",
+  BACKEND_OFFLINE: "pairing.invalid",  # RFC 2606 .invalid never resolves
 }
 
 CACHE_PARAM = {

--- a/launch_env.sh
+++ b/launch_env.sh
@@ -39,7 +39,8 @@ if [ "$BP_CONNECT_BACKEND" = "1" ]; then
   export API_HOST="https://api.konik.ai"
   export ATHENA_HOST="wss://athena.konik.ai"
 elif [ "$BP_CONNECT_BACKEND" = "2" ]; then
-  export API_HOST="https://api.imoffline.net"
-  export ATHENA_HOST="wss://athena.imoffline.net"
+  # RFC 2606 .invalid never resolves, so offline mode can never egress
+  export API_HOST="https://api.invalid"
+  export ATHENA_HOST="wss://athena.invalid"
 fi
 # End BluePilot


### PR DESCRIPTION


<!-- Please copy and paste the relevant template -->


**Description**

`imoffline.net` is an unregistered public domain — anyone could register it and receive the signed JWT athenad sends in its connect headers plus pairing tokens from devices in offline mode. 

Names under `.invalid` are guaranteed to never resolve (RFC 2606 / RFC 6761), so offline mode can never egress.

**Verification**

I didn't test it, but it should be broken anyway, right?





