### PR TITLE
Allow user to choose from Comma 4 or Comma 3x Driver Monitoring Icon

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -336,8 +336,9 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"BPRainbowLines", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"BPShowConfidenceBall", {PERSISTENT | BACKUP, BOOL, "1"}},
     {"BPAnimateSteeringWheel", {PERSISTENT | BACKUP, BOOL, "1"}},
-    // BluePilot: No static default; the first active UI persists its matching device style (C4=0, C3X=1).
+    // BluePilot: No static defaults; the first active UI persists its matching device styles (C4=0, C3X=1).
     {"BPSteeringWheelIconStyle", {PERSISTENT | BACKUP, INT}},
+    {"BPDMStylingChoice", {PERSISTENT | BACKUP, INT}},
     {"BpShowLateralControl", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"BPDisableLaneLineStatusColor", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"BPUIDebugLog", {PERSISTENT, BOOL, "0"}},

--- a/selfdrive/ui/bp/layouts/settings/bluepilot.py
+++ b/selfdrive/ui/bp/layouts/settings/bluepilot.py
@@ -19,6 +19,11 @@ from openpilot.selfdrive.ui.bp.lib.steering_wheel_style import (
   get_steering_wheel_icon_style,
   SteeringWheelIconStyle,
 )
+from openpilot.selfdrive.ui.bp.lib.dm_icon_style import (
+  DMIconStyle,
+  ensure_dm_icon_style_initialized,
+  get_dm_icon_style,
+)
 from opendbc.sunnypilot.car.ford.lateral_curv_ext import PrimaryLateralControl
 from openpilot.selfdrive.ui.bp.onroad.augmented_road_view_bp import GaugeStyle
 
@@ -192,6 +197,17 @@ class BluePilotLayout(Widget):
       callback=self._set_wheel_icon_style,
       selected_index=wheel_style_idx,
       icon="chffr_wheel.png"
+    )
+
+    dm_style_idx = int(ensure_dm_icon_style_initialized(self._params, DMIconStyle.COMMA_3X))
+    self._dm_icon_style_btn = multiple_button_item(
+      lambda: tr("DM Icon Style"),
+      lambda: tr("Toggle Driver Monitoring icon style between Comma 4 and Comma 3x"),
+      buttons=[lambda: tr("Comma 4"), lambda: tr("Comma 3x")],
+      button_width=225,
+      callback=self._set_dm_icon_style,
+      selected_index=dm_style_idx,
+      icon="monitoring.png"
     )
 
     # Ford radar lead overlay toggle
@@ -606,6 +622,7 @@ class BluePilotLayout(Widget):
         self._show_confidence_ball,
         self._animate_steering_wheel,
         self._wheel_icon_style_btn,
+        self._dm_icon_style_btn,
         self._show_ford_radar_overlay,
         self._radar_overlay_size_btn,
         self._show_hybrid_battery_status,
@@ -702,6 +719,8 @@ class BluePilotLayout(Widget):
 
     wheel_style_idx = int(get_steering_wheel_icon_style(ui_state.params, SteeringWheelIconStyle.COMMA_3X))
     self._wheel_icon_style_btn.action_item.set_selected_button(wheel_style_idx)
+    dm_style_idx = int(get_dm_icon_style(ui_state.params, DMIconStyle.COMMA_3X))
+    self._dm_icon_style_btn.action_item.set_selected_button(dm_style_idx)
 
     # Update button enabled states
     self._radar_overlay_size_btn.action_item.set_enabled(self._safe_get_bool(ui_state.params, "FordPrefShowRadarLeadOverlay"))
@@ -883,6 +902,10 @@ class BluePilotLayout(Widget):
   def _set_wheel_icon_style(self, button_index: int):
     """Handle wheel icon style: 0 = comma 4, 1 = comma 3X."""
     self._params.put("BPSteeringWheelIconStyle", button_index)
+
+  def _set_dm_icon_style(self, button_index: int):
+    """Handle DM icon style: 0 = comma 4, 1 = comma 3X."""
+    self._params.put("BPDMStylingChoice", button_index)
 
   def _set_hybrid_gauge_size(self, button_index: int):
     """Handle hybrid gauge size button selection. Buttons are 0/1/2, param stores 1/2/3."""

--- a/selfdrive/ui/bp/lib/dm_icon_style.py
+++ b/selfdrive/ui/bp/lib/dm_icon_style.py
@@ -1,0 +1,25 @@
+from enum import IntEnum
+
+from openpilot.common.params import Params
+from openpilot.selfdrive.ui.bp.lib.int_enum_param import (
+  ensure_int_enum_param_initialized,
+  get_int_enum_param,
+)
+
+
+PARAM_KEY = "BPDMStylingChoice"
+
+
+class DMIconStyle(IntEnum):
+  COMMA_4 = 0
+  COMMA_3X = 1
+
+
+def get_dm_icon_style(params: Params, device_default: DMIconStyle) -> DMIconStyle:
+  """Return the configured driver-monitoring icon style without modifying Params."""
+  return get_int_enum_param(params, PARAM_KEY, DMIconStyle, device_default)
+
+
+def ensure_dm_icon_style_initialized(params: Params, device_default: DMIconStyle) -> DMIconStyle:
+  """Persist the device default when the DM-style param is missing or invalid."""
+  return ensure_int_enum_param_initialized(params, PARAM_KEY, DMIconStyle, device_default)

--- a/selfdrive/ui/bp/lib/int_enum_param.py
+++ b/selfdrive/ui/bp/lib/int_enum_param.py
@@ -1,0 +1,43 @@
+from enum import IntEnum
+
+from openpilot.common.params import Params
+from openpilot.common.params_pyx import UnknownKeyName
+
+
+def get_int_enum_param[IntEnumT: IntEnum](
+  params: Params,
+  key: str,
+  enum_type: type[IntEnumT],
+  default: IntEnumT,
+) -> IntEnumT:
+  """Return a validated enum-backed integer param without modifying Params."""
+  try:
+    raw_value = params.get(key)
+  except UnknownKeyName:
+    # BluePilot: Allow UI development before common/params_pyx.so has been rebuilt.
+    return default
+
+  try:
+    return enum_type(raw_value) if raw_value is not None else default
+  except (TypeError, ValueError):
+    return default
+
+
+def ensure_int_enum_param_initialized[IntEnumT: IntEnum](
+  params: Params,
+  key: str,
+  enum_type: type[IntEnumT],
+  default: IntEnumT,
+) -> IntEnumT:
+  """Return a validated enum-backed param and persist the default when needed."""
+  value = get_int_enum_param(params, key, enum_type, default)
+
+  try:
+    raw_value = params.get(key)
+  except UnknownKeyName:
+    return value
+
+  if raw_value != int(value):
+    params.put(key, int(value), block=False)
+
+  return value

--- a/selfdrive/ui/bp/lib/steering_wheel_style.py
+++ b/selfdrive/ui/bp/lib/steering_wheel_style.py
@@ -1,7 +1,13 @@
 from enum import IntEnum
 
 from openpilot.common.params import Params
-from openpilot.common.params_pyx import UnknownKeyName
+from openpilot.selfdrive.ui.bp.lib.int_enum_param import (
+  ensure_int_enum_param_initialized,
+  get_int_enum_param,
+)
+
+
+PARAM_KEY = "BPSteeringWheelIconStyle"
 
 
 class SteeringWheelIconStyle(IntEnum):
@@ -11,32 +17,12 @@ class SteeringWheelIconStyle(IntEnum):
 
 def get_steering_wheel_icon_style(params: Params, device_default: SteeringWheelIconStyle) -> SteeringWheelIconStyle:
   """Return the configured wheel style without modifying Params."""
-  try:
-    raw_style = params.get("BPSteeringWheelIconStyle")
-  except UnknownKeyName:
-    # BluePilot: Allow UI development before common/params_pyx.so has been rebuilt.
-    return device_default
-
-  try:
-    style = SteeringWheelIconStyle(raw_style) if raw_style is not None else device_default
-  except (TypeError, ValueError):
-    style = device_default
-
-  return style
+  return get_int_enum_param(params, PARAM_KEY, SteeringWheelIconStyle, device_default)
 
 
 def ensure_steering_wheel_icon_style_initialized(
-  params: Params, device_default: SteeringWheelIconStyle,
+  params: Params,
+  device_default: SteeringWheelIconStyle,
 ) -> SteeringWheelIconStyle:
   """Persist the device default when the wheel-style param is missing or invalid."""
-  style = get_steering_wheel_icon_style(params, device_default)
-
-  try:
-    raw_style = params.get("BPSteeringWheelIconStyle")
-  except UnknownKeyName:
-    return style
-
-  if raw_style != int(style):
-    params.put("BPSteeringWheelIconStyle", int(style), block=False)
-
-  return style
+  return ensure_int_enum_param_initialized(params, PARAM_KEY, SteeringWheelIconStyle, device_default)

--- a/selfdrive/ui/bp/mici/layouts/settings/visuals_mici.py
+++ b/selfdrive/ui/bp/mici/layouts/settings/visuals_mici.py
@@ -8,6 +8,11 @@ from openpilot.selfdrive.ui.bp.lib.steering_wheel_style import (
   get_steering_wheel_icon_style,
   SteeringWheelIconStyle,
 )
+from openpilot.selfdrive.ui.bp.lib.dm_icon_style import (
+  DMIconStyle,
+  ensure_dm_icon_style_initialized,
+  get_dm_icon_style,
+)
 from openpilot.selfdrive.ui.bp.mici.widgets.button_bp import (
   BigParamControlBP,
   BigMultiParamToggleBP,
@@ -39,6 +44,10 @@ class VisualsLayoutMici(NavScroller):
     self.wheel_icon_style = BigMultiParamToggleBP(
       "Wheel Icon Style", "BPSteeringWheelIconStyle", ["Comma 4", "Comma 3x"],
     )
+    ensure_dm_icon_style_initialized(Params(), DMIconStyle.COMMA_4)
+    self.dm_icon_style = BigMultiParamToggleBP(
+      "DM Icon Style", "BPDMStylingChoice", ["Comma 4", "Comma 3x"],
+    )
     self.show_hybrid_power_flow = BigParamControlBP("Show Hybrid Power Flow", "FordPrefHybridPowerFlow")
     self.hybrid_power_flow_style = BigMultiParamToggleBoolBP(
       "Hybrid/EV Power Flow Style", "FordPrefHybridPowerFlowAlternate", ["flat", "round"],
@@ -55,6 +64,7 @@ class VisualsLayoutMici(NavScroller):
       self.show_brake_status,
       self.animate_steering_wheel,
       self.wheel_icon_style,
+      self.dm_icon_style,
       self.show_hybrid_power_flow,
       self.hybrid_power_flow_style,
     ])
@@ -95,3 +105,5 @@ class VisualsLayoutMici(NavScroller):
       item.set_checked(ui_state.params.get_bool(key))
     wheel_style = get_steering_wheel_icon_style(ui_state.params, SteeringWheelIconStyle.COMMA_4)
     self.wheel_icon_style.set_value(self.wheel_icon_style._options[int(wheel_style)])
+    dm_style = get_dm_icon_style(ui_state.params, DMIconStyle.COMMA_4)
+    self.dm_icon_style.set_value(self.dm_icon_style._options[int(dm_style)])

--- a/selfdrive/ui/bp/mici/onroad/augmented_road_view_bp.py
+++ b/selfdrive/ui/bp/mici/onroad/augmented_road_view_bp.py
@@ -10,6 +10,8 @@ from openpilot.selfdrive.ui.bp.mici.onroad.cameraview_bp import MiciCameraViewBP
 from openpilot.selfdrive.ui.bp.mici.onroad.model_renderer_bp import ModelRendererBP
 from openpilot.selfdrive.ui.bp.onroad.blindspot_renderer import BlindspotRendererMixin
 from openpilot.selfdrive.ui.bp.mici.onroad.hud_renderer_bp import MiciHudRendererBP
+from openpilot.selfdrive.ui.bp.onroad.driver_state_bp import DriverStateRendererBP
+from openpilot.selfdrive.ui.bp.lib.dm_icon_style import DMIconStyle
 from openpilot.selfdrive.ui.bp.mici.onroad.complication import MiciComplication
 from openpilot.selfdrive.ui.bp.mici.onroad.confidence_ball_bp import ConfidenceBallMiciBP
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
@@ -75,6 +77,7 @@ class MiciAugmentedRoadViewBP(MiciCameraViewBP, AugmentedRoadView, BlindspotRend
 
     # BluePilot: Replace HUD renderer with BP version (brake coloring + powerflow)
     self._hud_renderer = MiciHudRendererBP()
+    self._driver_state_renderer = DriverStateRendererBP(DMIconStyle.COMMA_4)
 
     # BluePilot: Replace confidence ball with BP version on the left (MADS beam + enhanced coloring)
     self._confidence_ball = ConfidenceBallMiciBP()

--- a/selfdrive/ui/bp/onroad/augmented_road_view_bp.py
+++ b/selfdrive/ui/bp/onroad/augmented_road_view_bp.py
@@ -10,6 +10,8 @@ from openpilot.selfdrive.ui.bp.onroad.blindspot_renderer import BlindspotRendere
 from openpilot.selfdrive.ui.bp.onroad.hud_renderer_bp import HudRendererBP
 from openpilot.selfdrive.ui.bp.onroad.alert_renderer_bp import AlertRendererBP
 from openpilot.selfdrive.ui.bp.onroad.model_renderer_bp import ModelRendererBP
+from openpilot.selfdrive.ui.bp.onroad.driver_state_bp import DriverStateRendererBP
+from openpilot.selfdrive.ui.bp.lib.dm_icon_style import DMIconStyle
 from openpilot.selfdrive.ui.bp.onroad.hybrid_battery_gauge import HybridBatteryGauge
 from openpilot.selfdrive.ui.bp.onroad.hybrid_battery_gauge_arched import HybridBatteryGaugeArched, BATTERY_START_ANGLE
 from openpilot.selfdrive.ui.bp.onroad.power_flow_gauge import PowerFlowGauge
@@ -61,6 +63,7 @@ class AugmentedRoadViewBP(CameraViewBP, AugmentedRoadView, BlindspotRendererMixi
     self.model_renderer = ModelRendererBP()
     self._hud_renderer = HudRendererBP()
     self.alert_renderer = AlertRendererBP()
+    self.driver_state_renderer = DriverStateRendererBP(DMIconStyle.COMMA_3X)
     self._battery_gauge_bp = HybridBatteryGauge()
     self._power_flow_gauge = PowerFlowGauge()
     self._battery_gauge_arched = HybridBatteryGaugeArched()

--- a/selfdrive/ui/bp/onroad/driver_state_bp.py
+++ b/selfdrive/ui/bp/onroad/driver_state_bp.py
@@ -1,0 +1,195 @@
+"""BluePilot-selectable comma 4 / comma 3X driver-monitoring icon renderer."""
+
+import numpy as np
+import pyray as rl
+
+from openpilot.common.params import Params
+from openpilot.selfdrive.ui import UI_BORDER_SIZE
+from openpilot.selfdrive.ui.bp.lib.dm_icon_style import (
+  DMIconStyle,
+  ensure_dm_icon_style_initialized,
+  get_dm_icon_style,
+)
+from openpilot.selfdrive.ui.mici.onroad.driver_state import DriverStateRenderer as DriverStateRendererMici
+from openpilot.selfdrive.ui.onroad.driver_state import (
+  ARC_ANGLES,
+  ARC_LENGTH,
+  ARC_THICKNESS_DEFAULT,
+  ARC_THICKNESS_EXTEND,
+  BTN_SIZE,
+  IMG_SIZE,
+  ArcData,
+)
+from openpilot.selfdrive.ui.sunnypilot.onroad.developer_ui import get_bottom_dev_ui_offset
+from openpilot.selfdrive.ui.sunnypilot.onroad.driver_state import DriverStateRendererSP
+from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.system.ui.widgets import Widget
+
+
+PARAM_REFRESH_FRAMES = 60
+COMMA_4_ICON_SIZE = DriverStateRendererMici.BASE_SIZE
+
+
+class _CompactComma3XDriverStateRendererBP(DriverStateRendererSP):
+  """Scale the comma 3X DMoji into the comma 4 icon footprint."""
+
+  def __init__(self, icon_size: int):
+    super().__init__()
+    self._scale = icon_size / BTN_SIZE
+    face_size = max(1, round(IMG_SIZE * self._scale))
+    self.dm_img = gui_app.texture("icons/driver_face.png", face_size, face_size)
+
+  def _render(self, _rect: rl.Rectangle) -> None:
+    opacity = 0.65 if self.is_active else 0.2
+    button_size = BTN_SIZE * self._scale
+
+    rl.draw_circle(int(self.position_x), int(self.position_y), round(button_size / 2), rl.Color(0, 0, 0, 70))
+
+    icon_pos = rl.Vector2(self.position_x - self.dm_img.width / 2, self.position_y - self.dm_img.height / 2)
+    rl.draw_texture_v(self.dm_img, icon_pos, rl.Color(255, 255, 255, int(255 * opacity)))
+
+    self.white_color.a = int(255 * opacity)
+    rl.draw_spline_linear(self.face_lines, len(self.face_lines), max(1.0, 5.2 * self._scale), self.white_color)
+
+    self.arc_color = self.engaged_color if ui_state.engaged else self.disengaged_color
+    self.arc_color.a = int(0.4 * 255 * (1.0 - self.dm_fade_state))
+    if self.h_arc_data:
+      rl.draw_spline_linear(self.h_arc_lines, len(self.h_arc_lines), self.h_arc_data.thickness, self.arc_color)
+    if self.v_arc_data:
+      rl.draw_spline_linear(self.v_arc_lines, len(self.v_arc_lines), self.v_arc_data.thickness, self.arc_color)
+
+  def _pre_calculate_drawing_elements(self) -> None:
+    self.position_x = self._rect.x + self._rect.width / 2
+    self.position_y = self._rect.y + self._rect.height / 2
+
+    positioned_keypoints = self.face_keypoints_transformed * self._scale + np.array([self.position_x, self.position_y])
+    for i, point in enumerate(positioned_keypoints):
+      self.face_lines[i].x = point[0]
+      self.face_lines[i].y = point[1]
+
+    arc_length = ARC_LENGTH * self._scale
+    delta_x = -self.driver_pose_sins[1] * arc_length / 2.0
+    delta_y = -self.driver_pose_sins[0] * arc_length / 2.0
+    self.h_arc_data = self._calculate_scaled_arc_data(
+      delta_x,
+      abs(delta_x),
+      self.position_x,
+      self.position_y - arc_length / 2,
+      self.driver_pose_sins[1],
+      self.driver_pose_diff[1],
+      is_horizontal=True,
+    )
+    self.v_arc_data = self._calculate_scaled_arc_data(
+      delta_y,
+      abs(delta_y),
+      self.position_x - arc_length / 2,
+      self.position_y,
+      self.driver_pose_sins[0],
+      self.driver_pose_diff[0],
+      is_horizontal=False,
+    )
+
+  def _calculate_scaled_arc_data(
+    self,
+    delta: float,
+    size: float,
+    x: float,
+    y: float,
+    sin_val: float,
+    diff_val: float,
+    is_horizontal: bool,
+  ) -> ArcData | None:
+    if size <= 0:
+      return None
+
+    arc_length = ARC_LENGTH * self._scale
+    thickness = (ARC_THICKNESS_DEFAULT + ARC_THICKNESS_EXTEND * min(1.0, diff_val * 5.0)) * self._scale
+    start_angle = (90 if sin_val > 0 else -90) if is_horizontal else (0 if sin_val > 0 else 180)
+    x = min(x + delta, x) if is_horizontal else x
+    y = y if is_horizontal else min(y + delta, y)
+    arc_data = ArcData(
+      x=x,
+      y=y,
+      width=size if is_horizontal else arc_length,
+      height=arc_length if is_horizontal else size,
+      thickness=max(1.0, thickness),
+    )
+
+    angles = ARC_ANGLES + np.deg2rad(start_angle)
+    center_x = x + arc_data.width / 2
+    center_y = y + arc_data.height / 2
+    x_coords = center_x + np.cos(angles) * arc_data.width / 2
+    y_coords = center_y - np.sin(angles) * arc_data.height / 2
+    arc_lines = self.h_arc_lines if is_horizontal else self.v_arc_lines
+    for i, (x_coord, y_coord) in enumerate(zip(x_coords, y_coords, strict=True)):
+      arc_lines[i].x = x_coord
+      arc_lines[i].y = y_coord
+
+    return arc_data
+
+
+class DriverStateRendererBP(Widget):
+  """Render either native DMoji style while keeping each device's normal footprint."""
+
+  def __init__(self, device_default: DMIconStyle):
+    super().__init__()
+    self._params = Params()
+    self._device_default = device_default
+    self._style = ensure_dm_icon_style_initialized(self._params, device_default)
+    self._param_frame_counter = 0
+    self._should_draw = True
+    self._is_mici = device_default == DMIconStyle.COMMA_4
+
+    self._comma4_renderer = self._child(DriverStateRendererMici())
+    if self._is_mici:
+      self.set_rect(rl.Rectangle(0, 0, COMMA_4_ICON_SIZE, COMMA_4_ICON_SIZE))
+      self._comma3x_renderer = self._child(_CompactComma3XDriverStateRendererBP(COMMA_4_ICON_SIZE))
+    else:
+      self._comma4_renderer.set_rect(rl.Rectangle(0, 0, BTN_SIZE, BTN_SIZE))
+      self._comma4_renderer.load_icons()
+      self._comma4_renderer.set_should_draw(True)
+      self._comma3x_renderer = self._child(DriverStateRendererSP())
+
+  def set_should_draw(self, should_draw: bool) -> None:
+    self._should_draw = should_draw
+
+  @property
+  def is_rhd(self) -> bool:
+    renderer = self._comma4_renderer if self._style == DMIconStyle.COMMA_4 else self._comma3x_renderer
+    return bool(renderer.is_rhd)
+
+  def _update_state(self) -> None:
+    self._param_frame_counter += 1
+    if self._param_frame_counter >= PARAM_REFRESH_FRAMES:
+      self._param_frame_counter = 0
+      self._style = get_dm_icon_style(self._params, self._device_default)
+
+  def _render(self, rect: rl.Rectangle) -> None:
+    if self._is_mici:
+      self._render_mici(rect)
+    else:
+      self._render_tici(rect)
+
+  def _render_mici(self, rect: rl.Rectangle) -> None:
+    if self._style == DMIconStyle.COMMA_4:
+      if self._comma4_renderer.rect.width != rect.width or self._comma4_renderer.rect.height != rect.height:
+        self._comma4_renderer.set_rect(rl.Rectangle(rect.x, rect.y, rect.width, rect.height))
+        self._comma4_renderer.load_icons()
+      else:
+        self._comma4_renderer.set_position(rect.x, rect.y)
+      self._comma4_renderer.set_should_draw(self._should_draw)
+      self._comma4_renderer.render()
+    elif self._should_draw:
+      self._comma3x_renderer.render(rect)
+
+  def _render_tici(self, rect: rl.Rectangle) -> None:
+    if self._style == DMIconStyle.COMMA_3X:
+      self._comma3x_renderer.render(rect)
+      return
+
+    is_rhd = ui_state.sm["driverMonitoringState"].isRHD
+    x = rect.x + rect.width - UI_BORDER_SIZE - BTN_SIZE if is_rhd else rect.x + UI_BORDER_SIZE
+    y = rect.y + rect.height - UI_BORDER_SIZE - BTN_SIZE - get_bottom_dev_ui_offset()
+    self._comma4_renderer.set_position(x, y)
+    self._comma4_renderer.render()

--- a/sunnypilot/sunnylink/settings_ui.json
+++ b/sunnypilot/sunnylink/settings_ui.json
@@ -2221,6 +2221,22 @@
           ]
         },
         {
+          "key": "BPDMStylingChoice",
+          "widget": "multiple_button",
+          "title": "[Visuals] DM Icon Style",
+          "description": "Toggle Driver Monitoring icon style between Comma 4 and Comma 3x",
+          "options": [
+            {
+              "value": 0,
+              "label": "Comma 4"
+            },
+            {
+              "value": 1,
+              "label": "Comma 3x"
+            }
+          ]
+        },
+        {
           "key": "BpShowLateralControl",
           "widget": "toggle",
           "title": "[Visuals] Show Lateral Control Mode",

--- a/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
+++ b/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
@@ -92,7 +92,7 @@ sections:
     widget: toggle
     title: '[Visuals] Animate Steering Wheel'
     description: Rotate the steering wheel icon to match the current steering angle.
-  # ==================== BLUEPILOT SUNNYLINK WHEEL STYLE ====================
+  # ==================== BLUEPILOT SUNNYLINK ICON STYLES ====================
   - key: BPSteeringWheelIconStyle
     widget: multiple_button
     title: '[Visuals] Wheel Icon Style'
@@ -102,6 +102,16 @@ sections:
       label: Comma 4
     - value: 1
       label: Comma 3x
+  - key: BPDMStylingChoice
+    widget: multiple_button
+    title: '[Visuals] DM Icon Style'
+    description: Toggle Driver Monitoring icon style between Comma 4 and Comma 3x
+    options:
+    - value: 0
+      label: Comma 4
+    - value: 1
+      label: Comma 3x
+  # ================== END BLUEPILOT SUNNYLINK ICON STYLES ==================
   - key: BpShowLateralControl
     widget: toggle
     title: '[Visuals] Show Lateral Control Mode'


### PR DESCRIPTION
Adds toggle under BluePilot --> Visuals and Sunnypilot --> Vehicle tab that lets the user choose between having the Comma 4 or Comma 3x DM icon shown on screen.

By default, the DM icon style option will be whichever is native to the hardware it's running on.


**_This does not modify the behavior of driver monitoring at all_**