### PR TITLE
Ford Expedition Mk4: add 2023 ABS FW + mark EPS non-essential

### DIFF
--- a/opendbc_repo/opendbc/car/ford/fingerprints.py
+++ b/opendbc_repo/opendbc/car/ford/fingerprints.py
@@ -110,6 +110,7 @@ FW_VERSIONS = {
     ],
     (Ecu.abs, 0x760, None): [
       b'RL14-2D053-AA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+      b'PL14-2D053-AB\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.fwdRadar, 0x764, None): [
       b'ML3T-14D049-AL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',

--- a/opendbc_repo/opendbc/car/ford/values.py
+++ b/opendbc_repo/opendbc/car/ford/values.py
@@ -330,7 +330,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   # non-essential for MK1 so the missing Ford-tagged matching-eligible EPS
   # response doesn't block matching. The unique TL38-2D053-AD (ABS) +
   # RB5T-14D049-AB (radar) FWs still identify MK1 cleanly.
-  non_essential_ecus={Ecu.eps: [CAR.FORD_F_150_LIGHTNING_MK1]},
+  non_essential_ecus={Ecu.eps: [CAR.FORD_F_150_LIGHTNING_MK1, CAR.FORD_EXPEDITION_MK4]},
   # Custom fuzzy fingerprinting function using platform and model year hints
   match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )


### PR DESCRIPTION
## Summary
Adds the **2023 Ford Expedition Limited** to the existing `FORD_EXPEDITION_MK4` platform:

1. **fingerprints.py** — add ABS FW `PL14-2D053-AB`. On this truck, `eps`/`fwdRadar`/`fwdCamera` already matched the existing entry byte-for-byte; ABS was the only differing ECU (the entry listed only `RL14-2D053-AA`).
2. **values.py** — add `FORD_EXPEDITION_MK4` to `non_essential_ecus[Ecu.eps]`. This truck's EPS (`NL14-14D003-AE`) answers only the Mazda-style UDS query, so its Ford-tagged response comes back `logging=True` and is filtered out of the matching dict — the same Flash-EPS behavior already handled for `FORD_F_150_LIGHTNING_MK1`. Without this, the required `eps` entry blocks an exact match.

## Evidence
On stock `bp-dev` / `FORD_EXPEDITION_MK4`, the truck fingerprinted as "Car Unrecognized." Device logs:
- `iso-tp query bad response: (0x730, None) - 0x7f2231` — EPS rejects the Ford query (svc `0x22`, NRC `0x31` requestOutOfRange)
- `fingerprinted` event: `car_fingerprint: None`; ECU responses for abs(0x760)/fwdRadar(0x764)/fwdCamera(0x706)/engine(0x7E0), **no eps**
- ABS on the wire: `PL14-2D053-AB` (entry listed only `RL14-2D053-AA`)

With both changes it fingerprints as `FORD_EXPEDITION_MK4` via **exact FW match** (`source: fw`, `fuzzy: false`).

## carFw (Ford, matching-eligible)
| ECU | addr | FW |
|-----|------|-----|
| eps | 0x730 | `NL14-14D003-AE` (Mazda-query only) |
| abs | 0x760 | `PL14-2D053-AB` |
| fwdRadar | 0x764 | `ML3T-14D049-AL` |
| fwdCamera | 0x706 | `ML3T-14H102-ABT` |

`PL14-2D053-AB` is unique to the Expedition (F-150 = ML34/NL34/PL34/PL3V; Lightning = PL38/RL38/TL38), so exact match stays unambiguous with EPS non-essential.

## Vehicle & testing
- 2023 Ford Expedition Limited, 3.5L EcoBoost, Co-Pilot360 Assist 2.0
- Hardware: comma 4 + Ford Q4 harness (CAN FD)
- Fingerprints as `FORD_EXPEDITION_MK4` (exact FW). **Lateral control confirmed active** over a ~20-min drive (`carControl.latActive` true ~88% of samples, `controlsAllowedLateral` true, safety model `ford`); longitudinal left to stock ACC.

_Comma 4 note:_ harness reported `flipped` and bus 0 logged a burst of CAN errors during boot/init that cleared before driving (`busOff` never true while driving) — flagging in case it's relevant on that newer hardware.
