### PR TITLE
Ford: fire the stall-rescue pulse only on a fractional delivery deficit

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -101,6 +101,13 @@ _PSCM_SAT_UNWIND_RATE = 0.02        # rad/call (0.02 * 20Hz = 0.40 rad/s)
 # PSCM's authority, after which path_angle ramps back in from zero through the soft ROC.
 _STEER_DT = CarControllerParams.STEER_STEP * DT_CTRL  # 20 Hz lateral tick (matches human_turn.py)
 _STALL_GAP_MIN = 2.0 * CarControllerParams.CURVATURE_ERROR  # desired must lead measured by 2x the clip tolerance
+# A stall is a FRACTIONAL failure, not just an absolute gap: during an honest deep-curve
+# entry the car tracks at 0.7-0.85x of a large, fast-rising demand, which clears
+# _STALL_GAP_MIN on magnitude alone -- and a mid-curve pulse releases steering exactly
+# when the car is already behind (observed on-road: two such fires in one windy section,
+# each followed by the driver grabbing the wheel within 0.2 s). True stalls measure
+# 0.28-0.59x delivered across every diagnosed route; entry transients 0.64x and above.
+_STALL_DELIVERY_FRACTION = 0.65
 _STALL_HOLD_S = 0.5          # accumulated clip-binding time before a pulse fires
 _STALL_BLIP_FRAMES = 6       # mode-0 pulse length (6 frames @ 20 Hz = 300 ms; PSCM acked mode 0 in ~150 ms on-road)
 _STALL_COOLDOWN_S = 2.0      # re-arm delay after a pulse (release ramp + PSCM response time)
@@ -533,14 +540,16 @@ class LateralAngleExt:
 
     # Post-override stall detection (mechanism in the module constants' comment). Fires the mode-0
     # blip when, hands-free, desired curvature has led measured by more than 2x the deviation
-    # clip's tolerance while the clip was actually binding for _STALL_HOLD_S accumulated seconds.
+    # clip's tolerance AND the car is delivering under _STALL_DELIVERY_FRACTION of the demand,
+    # while the clip was actually binding for _STALL_HOLD_S accumulated seconds. The fractional
+    # condition separates a true stall from an honest deep-curve entry transient (see the constant).
     # devLim flickers mid-stall (~63% duty on the diagnosis route), so off frames hold the
     # accumulator rather than resetting it; a closed gap or driver press ends the episode.
     self.stall_blip_cooldown_s = max(0.0, self.stall_blip_cooldown_s - _STEER_DT)
     _stall_gap = desired_curvature - current_curvature
     _stalled = (not CS.out.steeringPressed and not self.lane_change and v_ego > 9.0
                 and abs(_stall_gap) > _STALL_GAP_MIN
-                and abs(desired_curvature) > abs(current_curvature))
+                and abs(current_curvature) < _STALL_DELIVERY_FRACTION * abs(desired_curvature))
     if _stalled:
       if self.bp_curvature_deviation_limited and self.stall_blip_cooldown_s <= 0.0:
         self.stall_blip_hold_s += _STEER_DT

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lateral_angle_ext.py
@@ -202,5 +202,32 @@ class TestInitializeFord(unittest.TestCase):
     self.assertIs(type(CP_SP.safetyParam), int)
 
 
+class TestStallFractionalGate(unittest.TestCase):
+  """The stall pulse must arm on a FRACTIONAL delivery deficit, not absolute gap alone:
+  an honest deep-curve entry tracks at 0.7-0.85x of a large demand and clears
+  _STALL_GAP_MIN on magnitude, but is not a stall. Yaw mode (flag off) throughout --
+  this gate is measurement-source independent."""
+
+  def _drive(self, desired, measured, frames=20, v_ego=10.0):
+    # measured curvature comes exactly from yawRate / v; at v > 9 the deviation clip
+    # binds on the gap, so devLim provides the detector's charging path.
+    ext, CP = _pinion_harness(flag=False)
+    cs = _CS(vEgoRaw=v_ego, vEgo=v_ego, yawRate=-measured * v_ego, steeringAngleDeg=0.0)
+    for _ in range(frames):
+      ext.update_angle_strategy(_CC(latActive=True), cs, _Actuators(curvature=desired), CP)
+    return ext
+
+  def test_entry_transient_never_fires(self):
+    # delivering 0.72x of a deep demand: gap 0.007 > _STALL_GAP_MIN, but not a stall
+    ext = self._drive(desired=0.025, measured=0.018)
+    self.assertEqual(ext.stall_blip_count, 0)
+    self.assertEqual(ext.stall_blip_hold_s, 0.0)
+
+  def test_true_stall_still_fires(self):
+    # delivering 0.2x of the same demand: fractional failure -> pulse
+    ext = self._drive(desired=0.025, measured=0.005)
+    self.assertEqual(ext.stall_blip_count, 1)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The angle-mode reactive stall detector (the 300 ms mode-0 "rescue pulse" that resets
post-override PSCM attenuation) arms on `|desired| > |measured|` plus an absolute gap
threshold. That condition cannot tell a stalled PSCM from an honestly-lagging one: on a
deep curve **entry** the car tracks at 0.7–0.85× of a large, fast-rising demand, clears
the gap threshold on magnitude alone, and the pulse releases steering mid-curve exactly
when the car is already behind.

## The evidence that motivated this

- On one windy section of a single drive (route `0000001e--be********`, 25–31 mph,
  |desired curvature| 0.016–0.021), the detector fired twice mid-curve while the car was
  delivering 0.71–0.83× — each pulse followed by the driver grabbing the wheel within
  0.2 s.
- Settled hands-off delivery on the same drive measured ~1.0 in every speed band: these
  were entry transients, not stalls.
- True stalls measure differently: 0.28–0.59× delivered, across five diagnosed routes
  (~47 engaged minutes).

## Why the fix is shaped this way

A stall is a **fractional** failure, not an absolute gap. The pulse now arms only when
the car is delivering under **0.65×** of the demand (`_STALL_DELIVERY_FRACTION`) — one
constant and one condition. The measured separation is wide: every true stall in the
archive sits at ≤ 0.59×, every honest transient at ≥ 0.71×. All other guards (0.5 s
hold, 2 s cooldown, 3-pulse episode cap, press/lane-change resets) are untouched, so a
genuinely stuck PSCM is rescued exactly as before.

## The evidence afterwards

Detector replay, ported verbatim and measurement-faithful (live steer ratio,
instantaneous angle offset, roll compensation, the recorded devLim flag), across five
routes:

- **Baseline reproduces every recorded pulse** — including both misfires — so the sim
  is calibrated, not curve-fit.
- **With the fractional gate**: every true rescue kept (all fire at 0.28–0.59×
  delivered), both misfires eliminated, zero new fires anywhere.

**On-road since opening** (update, two drives on a branch carrying this gate): a windy
hands-on route (`00000027--97********`, 26 min) crossed 38 qualifying curve entries with
**zero entry-transient fires** — a per-blip audit shows the gate honored on every pulse
that did fire — while a true stall still rescued cleanly; a follow-up drive
(`0000002a--ce********`) fired 4 pulses, each in a legitimate post-press window, zero
misfires. The gate's exact claim, confirmed on the road in its target scenario.

## What each change is

1. `_STALL_DELIVERY_FRACTION = 0.65` constant with the measured justification in the
   comment.
2. The arming condition's `abs(desired) > abs(measured)` becomes
   `abs(measured) < 0.65 * abs(desired)`.
3. New unit tests (plus the minimal test scaffolding for this module): an entry
   transient (0.72× of a deep demand, gap over threshold) must never fire; a true stall
   (0.20×) must.

## Test it yourself

```
# unit tests (no hardware)
cd opendbc_repo && pytest opendbc/sunnypilot/car/ford/tests/test_lateral_angle_ext.py

# on any Ford angle-mode route: count mode-0 pulses and check the delivery ratio at
# each fire — with this change, every fire should sit well under 0.65x
```

## Risks / limits

- Strictly reduces when the pulse fires; no new firing conditions. A stall that hovers
  just above 0.65× delivered will no longer pulse — by measurement, everything in that
  band was an honest transient the pulse made worse.
- **Should land before #153.** This is independent of the pinion measurement (#145,
  now merged) and applies in yaw mode too. #153 extends the stall rescue down to 5 m/s
  with the pinion measurement, which widens exposure to the *old* absolute-gap trigger
  this PR replaces — merged in the other order, #153 carries a known-imperfect trigger
  into a new speed range. A further flag-on follow-up (1.5× gap floor for the pinion
  path, validated jointly with this gate) comes after both.
- Rebased onto bp-dev after #145 merged. The only conflict was the Ford ext test file:
  this branch had added a self-contained scaffold back when bp-dev had no
  `car/ford/tests/`, and #145 has since added a fuller one. Resolved by keeping #145's
  scaffold and porting `TestStallFractionalGate` onto its `_pinion_harness(flag=False)`
  — the detector change itself applied unchanged.



