### PR TITLE
ui: port Rad Racer 8-bit theme to the comma four (MICI)

### DIFF
--- a/selfdrive/ui/bp/mici/layouts/settings/visuals_mici.py
+++ b/selfdrive/ui/bp/mici/layouts/settings/visuals_mici.py
@@ -33,6 +33,7 @@ class VisualsLayoutMici(NavScroller):
       ["off", "lead car speed", "speed", "lead car distance", "time to lead car"],
     )
     self.rainbow_mode = BigParamControlBP("Rainbow Mode", "RainbowMode")
+    self.rad_racer_theme = BigParamControlBP("8-Bit Racer Theme", "BPRadRacerTheme")
     self.hide_fade = BigParamControlBP("Hide Onroad Fade", "mici_hide_onroad_fade")
     self.hide_border = BigParamControlBP("Hide Onroad Border", "BPHideOnroadBorder")
     self.hide_camera_view = BigParamControlBP("Minimal Driving View", "BPHideCameraView")
@@ -56,6 +57,7 @@ class VisualsLayoutMici(NavScroller):
     self._scroller.add_widgets([
       self.show_lead_vehicle,
       self.rainbow_mode,
+      self.rad_racer_theme,
       self.hide_fade,
       self.hide_border,
       self.hide_camera_view,
@@ -71,6 +73,7 @@ class VisualsLayoutMici(NavScroller):
 
     self._refresh_toggles = (
       ("RainbowMode", self.rainbow_mode),
+      ("BPRadRacerTheme", self.rad_racer_theme),
       ("mici_hide_onroad_fade", self.hide_fade),
       ("BPHideOnroadBorder", self.hide_border),
       ("BPHideCameraView", self.hide_camera_view),

--- a/selfdrive/ui/bp/mici/onroad/augmented_road_view_bp.py
+++ b/selfdrive/ui/bp/mici/onroad/augmented_road_view_bp.py
@@ -18,6 +18,7 @@ from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.selfdrive.ui.bp.lib.ui_debug_logger import bp_ui_log
 # BluePilot: swipe-down shortcut to lateral debug screen
 from openpilot.selfdrive.ui.bp.mici.onroad.lateral_debug_mici import LateralDebugMici
+from openpilot.selfdrive.ui.bp.mici.onroad.rad_racer_mici import RadRacerThemeMici
 from openpilot.system.ui.widgets import Widget
 
 # BluePilot: Margin to keep confidence ball inside the MICI rounded border
@@ -89,6 +90,11 @@ class MiciAugmentedRoadViewBP(MiciCameraViewBP, AugmentedRoadView, BlindspotRend
     self._lat_debug: LateralDebugMici | None = None
     self._swipe_detector = _VerticalSwipeDetector(self._on_swipe_down)
 
+    # BluePilot: Rad Racer 8-bit theme (MICI-scaled; no gauge cluster on the small screen)
+    self._rad_racer_theme = RadRacerThemeMici()
+    self._rad_racer_active = self._bp_params.get_bool("BPRadRacerTheme")
+    self._rad_racer_param_counter = 0
+
   def _on_swipe_down(self):
     if not ui_state.is_onroad():
       return
@@ -138,8 +144,24 @@ class MiciAugmentedRoadViewBP(MiciCameraViewBP, AugmentedRoadView, BlindspotRend
     # Render the base camera view. Minimal Driving View suppression lives in MiciCameraViewBP.
     MiciCameraViewBP._render(self, self._content_rect)
 
+    # BluePilot: Rad Racer theme — refresh cached param (~1s), then sky/skyline/signs behind the road
+    self._rad_racer_param_counter += 1
+    if self._rad_racer_param_counter >= 60:
+      self._rad_racer_param_counter = 0
+      self._rad_racer_active = self._bp_params.get_bool("BPRadRacerTheme")
+    if self._rad_racer_active:
+      self._model_renderer.prepare_projection(self._content_rect)
+      self._rad_racer_theme.render_background(self._content_rect, self._model_renderer)
+
     # Model overlays
     self._model_renderer.render(self._content_rect)
+
+    # BluePilot: Rad Racer sprites (ego + leads) over the road; no gauge cluster on MICI,
+    # so the ego car anchors to the bottom edge of the content rect instead.
+    if self._rad_racer_active:
+      self._rad_racer_theme.render_foreground(
+        self._content_rect, self._model_renderer,
+        self._content_rect.y + self._content_rect.height - 4)
 
     # Fade out bottom overlay (only when engaged)
     fade_alpha = self._fade_alpha_filter.update(ui_state.status != UIStatus.DISENGAGED)

--- a/selfdrive/ui/bp/mici/onroad/cameraview_bp.py
+++ b/selfdrive/ui/bp/mici/onroad/cameraview_bp.py
@@ -13,6 +13,8 @@ class MiciCameraViewBP(MiciCameraView):
     super().__init__(*args, **kwargs)
     self._bp_camera_params = Params()
     self._bp_hide_camera_view = self._bp_camera_params.get_bool("BPHideCameraView")
+    # BluePilot: Rad Racer theme draws its own scene over a black sky (mirrors TICI)
+    self._bp_rad_racer_theme = self._bp_camera_params.get_bool("BPRadRacerTheme")
     self._bp_camera_param_counter = 0
 
   def _update_state(self):
@@ -21,10 +23,11 @@ class MiciCameraViewBP(MiciCameraView):
     if self._bp_camera_param_counter >= 60:
       self._bp_camera_param_counter = 0
       self._bp_hide_camera_view = self._bp_camera_params.get_bool("BPHideCameraView")
+      self._bp_rad_racer_theme = self._bp_camera_params.get_bool("BPRadRacerTheme")
 
   def _should_hide_camera_view(self) -> bool:
     return (
-      self._bp_hide_camera_view and
+      (self._bp_hide_camera_view or self._bp_rad_racer_theme) and
       ui_state.is_onroad() and
       self._stream_type != VisionStreamType.VISION_STREAM_DRIVER
     )

--- a/selfdrive/ui/bp/mici/onroad/model_renderer_bp.py
+++ b/selfdrive/ui/bp/mici/onroad/model_renderer_bp.py
@@ -1,19 +1,35 @@
 import numpy as np
 import pyray as rl
 from openpilot.common.params import Params
-from openpilot.selfdrive.ui.mici.onroad.model_renderer import ModelRenderer, THROTTLE_COLORS, NO_THROTTLE_COLORS
+from openpilot.selfdrive.ui.mici.onroad.model_renderer import ModelRenderer, THROTTLE_COLORS, NO_THROTTLE_COLORS, CLIP_MARGIN
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
+from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.lib.shader_polygon import draw_polygon, Gradient
 # BluePilot: Rainbow shader moved to BP module after upstream removal
 from openpilot.bluepilot.ui.lib.bp_shaders import draw_rainbow_polygon
+# BluePilot: Rad Racer 8-bit road, shared with the TICI renderer
+from openpilot.selfdrive.ui.bp.onroad.rad_racer_road import RadRacerRoadMixin, RAD_RACER_DASH_LEN_M, RAD_RACER_GAP_LEN_M
 
-class ModelRendererBP(ModelRenderer):
+class ModelRendererBP(RadRacerRoadMixin, ModelRenderer):
   def __init__(self):
     super().__init__()
     self._bp_params = Params()
     self._rainbow_v = 20
     self._disable_lane_line_status_color = self._bp_params.get_bool("BPDisableLaneLineStatusColor")
     self._rainbow_lane_lines = self._bp_params.get_bool("BPRainbowLines")
+    # BluePilot: Rad Racer 8-bit theme (green game road; dash scroll animation state)
+    self._rad_racer = self._bp_params.get_bool("BPRadRacerTheme")
+    self._dash_phase = 0.0
+
+  def prepare_projection(self, rect: rl.Rectangle) -> None:
+    """Set clip region so _map_to_screen works before render().
+
+    Rad Racer draws skyline/signs behind the road and calls _map_to_screen during
+    that background pass, before the base render() initializes the clip rect.
+    """
+    self._clip_region = rl.Rectangle(
+      rect.x - CLIP_MARGIN, rect.y - CLIP_MARGIN, rect.width + 2 * CLIP_MARGIN, rect.height + 2 * CLIP_MARGIN
+    )
 
   def _update_state(self):
     super()._update_state()
@@ -22,12 +38,21 @@ class ModelRendererBP(ModelRenderer):
     if self._counter % 60 == 0:
       self._disable_lane_line_status_color = self._bp_params.get_bool("BPDisableLaneLineStatusColor")
       self._rainbow_lane_lines = self._bp_params.get_bool("BPRainbowLines")
+      self._rad_racer = self._bp_params.get_bool("BPRadRacerTheme")
 
     if ui_state.rainbow_path or self._rainbow_lane_lines:
       v = sm['carState'].vEgo
       self._rainbow_v = np.clip(v, 2.5, 35) / 30
 
+    # BluePilot: Advance dash scroll animation for the Rad Racer road
+    if self._rad_racer and sm.valid.get('carState', False):
+      period = RAD_RACER_DASH_LEN_M + RAD_RACER_GAP_LEN_M
+      self._dash_phase = (self._dash_phase + max(0.0, sm['carState'].vEgo) / gui_app.target_fps) % period
+
   def _draw_path(self, sm):
+    # BluePilot: Rad Racer theme draws the path ribbon in _draw_rad_racer_road
+    if self._rad_racer:
+      return
     if ui_state.rainbow_path:
       draw_rainbow_polygon(self._rect, self._path.projected_points, rainbow_v=self._rainbow_v)
     else:
@@ -35,6 +60,10 @@ class ModelRendererBP(ModelRenderer):
 
   def _draw_lane_lines(self):
     """Draw lane lines and road edges, with optional rainbow inner lane lines."""
+    # BluePilot: Rad Racer theme replaces all road rendering with the 8-bit game road
+    if self._rad_racer:
+      self._draw_rad_racer_road()
+      return
     offset = np.array([self._rect.x, self._rect.y], dtype=np.float32)
     rainbow_lane_lines_active = self._rainbow_lane_lines_active(ui_state.sm)
 

--- a/selfdrive/ui/bp/mici/onroad/rad_racer_mici.py
+++ b/selfdrive/ui/bp/mici/onroad/rad_racer_mici.py
@@ -1,0 +1,21 @@
+"""
+BluePilot: Rad Racer 8-bit theme, comma four (MICI) variant.
+
+Same scene as the TICI theme (sky, stars, skyline, roadside signs, car sprites) rescaled
+for the 536x240 MICI display. The gauge cluster is deliberately not rendered on MICI --
+at 240 px tall it would cover the entire screen, and the MICI HUD/complication already
+shows speed and lead info. The host (MiciAugmentedRoadViewBP) therefore only calls
+render_background() / render_foreground(), never render_cluster().
+"""
+from openpilot.selfdrive.ui.bp.onroad.rad_racer_theme import RadRacerTheme
+
+
+class RadRacerThemeMici(RadRacerTheme):
+  # ~0.25x of the TICI 2160x1080 values (see RadRacerTheme class attributes)
+  SKYLINE_PX_SCALE = 1.2       # 56 px skyline tex -> ~67 px band (~28% of 240 px height)
+  SKYLINE_MAX_OFFSET = 100.0
+  STAR_COUNT = 14
+  EGO_CAR_PX = 2.5             # 24 px ego tex -> 60 px (~11% of 536 px width)
+  EGO_CLUSTER_PAD = 2
+  LEAD_EGO_GAP = 6
+  LEAD_SPRITE_PX = (3.0, 1.5, 1.0)  # 16 px lead tex at dRel 5/40/100 m

--- a/selfdrive/ui/bp/onroad/model_renderer_bp.py
+++ b/selfdrive/ui/bp/onroad/model_renderer_bp.py
@@ -34,20 +34,14 @@ MINIMAL_VIEW_ROAD_EDGE_WIDTH = 0.075
 MINIMAL_VIEW_NEUTRAL_LANE_COLOR = rl.Color(185, 205, 225, 255)
 
 # BluePilot: Rad Racer 8-bit theme road styling
-RAD_RACER_ROAD_EDGE_WIDTH = 0.24       # solid outer lines (meters, half-width)
-RAD_RACER_DASH_HALF_WIDTH = 0.09       # dashed lane line quad half-width (meters)
-RAD_RACER_DASH_LEN_M = 4.0
-RAD_RACER_GAP_LEN_M = 4.0
-RAD_RACER_CURB_LEN_M = 3.0             # length of each red/white curb block (meters)
-RAD_RACER_GREEN = rl.Color(72, 216, 0, 255)
-RAD_RACER_DIM = rl.Color(110, 110, 110, 255)  # road color when disengaged
-RAD_RACER_PATH_SHADE = rl.Color(150, 255, 120, 110)      # planned path fill when engaged
-RAD_RACER_PATH_SHADE_DIM = rl.Color(120, 120, 120, 80)   # planned path fill when disengaged
-RAD_RACER_CURB_RED = rl.Color(255, 48, 48, 255)
-RAD_RACER_CURB_WHITE = rl.Color(255, 255, 255, 255)
+# BluePilot: Rad Racer road constants + drawing methods moved to rad_racer_road.py so the
+# comma four (MICI) renderer can share them; values unchanged.
+from openpilot.selfdrive.ui.bp.onroad.rad_racer_road import (  # noqa: E402
+  RadRacerRoadMixin, RAD_RACER_ROAD_EDGE_WIDTH, RAD_RACER_DASH_LEN_M, RAD_RACER_GAP_LEN_M,
+)
 
 
-class ModelRendererBP(ModelRenderer):
+class ModelRendererBP(RadRacerRoadMixin, ModelRenderer):
   """BluePilot ModelRenderer with enhanced lane lines, path smoothing, and radar overlay."""
 
   def __init__(self):
@@ -327,106 +321,9 @@ class ModelRendererBP(ModelRenderer):
       return
     self._draw_enhanced_lane_lines()
 
-  def _rad_racer_road_color(self) -> rl.Color:
-    """Green when lateral control is engaged, dim gray otherwise (safety cue)."""
-    if ui_state.status in (UIStatus.ENGAGED, UIStatus.OVERRIDE):
-      return RAD_RACER_GREEN
-    return RAD_RACER_DIM
-
-  def _draw_rad_racer_road(self):
-    """8-bit road: red/white curbs, light green planned path ribbon, dashed lane lines."""
-    color = self._rad_racer_road_color()
-
-    # Race-track curbs on the outer road edges
-    for i, road_edge in enumerate(self._road_edges):
-      if road_edge.raw_points.shape[0] < 2:
-        continue
-      edge_alpha = np.clip(1.0 - self._road_edge_stds[i], 0.3, 1.0)
-      self._draw_curbed_line(road_edge.raw_points, RAD_RACER_ROAD_EDGE_WIDTH, edge_alpha)
-
-    # Planned path ribbon — shaded fill so it reads clearly vs dashed lane lines
-    if self._path.projected_points.size > 0:
-      engaged = ui_state.status in (UIStatus.ENGAGED, UIStatus.OVERRIDE)
-      shade = RAD_RACER_PATH_SHADE if engaged else RAD_RACER_PATH_SHADE_DIM
-      draw_polygon(self._rect, self._path.projected_points, shade)
-
-    # Dashed lane lines
-    for i, lane_line in enumerate(self._lane_lines):
-      if self._lane_line_probs[i] < 0.4:
-        continue
-      self._draw_dashed_line(lane_line.raw_points, RAD_RACER_DASH_HALF_WIDTH, color, z_off=0.0)
-
-  def _draw_curbed_line(self, raw_points: np.ndarray, half_width: float, alpha: float = 1.0, z_off: float = 0.0):
-    """Draw a polyline as solid alternating red/white curb blocks (race-track edge)."""
-    if raw_points.shape[0] < 2:
-      return
-
-    xs = raw_points[:, 0]
-    x_min = max(float(xs[0]), 1.0)
-    x_max = min(float(xs[-1]), MAX_DRAW_DISTANCE)
-    if x_max <= x_min:
-      return
-
-    red = rl.Color(RAD_RACER_CURB_RED.r, RAD_RACER_CURB_RED.g, RAD_RACER_CURB_RED.b, int(255 * alpha))
-    white = rl.Color(RAD_RACER_CURB_WHITE.r, RAD_RACER_CURB_WHITE.g, RAD_RACER_CURB_WHITE.b, int(255 * alpha))
-    period = 2 * RAD_RACER_CURB_LEN_M
-    start = x_min - ((x_min + self._dash_phase) % period)
-    s = start
-    while s < x_max:
-      for offset, color in ((0.0, red), (RAD_RACER_CURB_LEN_M, white)):
-        x0 = max(s + offset, x_min)
-        x1 = min(s + offset + RAD_RACER_CURB_LEN_M, x_max)
-        if x1 <= x0:
-          continue
-        self._draw_road_ribbon_quad(raw_points, x0, x1, half_width, color, z_off)
-      s += period
-
-  def _draw_road_ribbon_quad(
-    self, raw_points: np.ndarray, x0: float, x1: float, half_width: float, color: rl.Color, z_off: float = 0.0,
-  ):
-    """Project one ribbon segment between x0 and x1 into screen space and fill it."""
-    xs = raw_points[:, 0]
-    y0 = float(np.interp(x0, xs, raw_points[:, 1]))
-    y1 = float(np.interp(x1, xs, raw_points[:, 1]))
-    z0 = float(np.interp(x0, xs, raw_points[:, 2])) + z_off
-    z1 = float(np.interp(x1, xs, raw_points[:, 2])) + z_off
-
-    p_near_l = self._map_to_screen(x0, y0 - half_width, z0)
-    p_near_r = self._map_to_screen(x0, y0 + half_width, z0)
-    p_far_r = self._map_to_screen(x1, y1 + half_width, z1)
-    p_far_l = self._map_to_screen(x1, y1 - half_width, z1)
-    if None in (p_near_l, p_near_r, p_far_r, p_far_l):
-      return
-
-    pts = [p_near_l, p_near_r, p_far_r, p_far_l]
-    area2 = sum(pts[i][0] * pts[(i + 1) % 4][1] - pts[(i + 1) % 4][0] * pts[i][1] for i in range(4))
-    if area2 > 0:
-      pts.reverse()
-    quad = [rl.Vector2(p[0], p[1]) for p in pts]
-    rl.draw_triangle_fan(quad, len(quad), color)
-
-  def _draw_dashed_line(self, raw_points: np.ndarray, half_width: float, color: rl.Color, z_off: float = 0.0):
-    """Draw a polyline as chunky scrolling dashes. Each dash is one projected quad."""
-    if raw_points.shape[0] < 2:
-      return
-
-    xs = raw_points[:, 0]
-    x_min = max(float(xs[0]), 1.0)
-    x_max = min(float(xs[-1]), MAX_DRAW_DISTANCE)
-    if x_max <= x_min:
-      return
-
-    period = RAD_RACER_DASH_LEN_M + RAD_RACER_GAP_LEN_M
-    # Dashes scroll toward the viewer as the car moves (phase advances with distance traveled)
-    start = x_min - ((x_min + self._dash_phase) % period)
-    s = start
-    while s < x_max:
-      x0 = max(s, x_min)
-      x1 = min(s + RAD_RACER_DASH_LEN_M, x_max)
-      s += period
-      if x1 <= x0:
-        continue
-      self._draw_road_ribbon_quad(raw_points, x0, x1, half_width, color, z_off)
+  # BluePilot: _rad_racer_road_color / _draw_rad_racer_road / _draw_curbed_line /
+  # _draw_road_ribbon_quad / _draw_dashed_line moved verbatim to RadRacerRoadMixin
+  # (rad_racer_road.py) so the comma four renderer can share them.
 
   def _get_ll_color(self, prob: float, is_current_lane: bool) -> rl.Color:
     """Get lane line color based on UI status with confidence-based brightness.

--- a/selfdrive/ui/bp/onroad/rad_racer_road.py
+++ b/selfdrive/ui/bp/onroad/rad_racer_road.py
@@ -1,0 +1,132 @@
+"""
+BluePilot: Rad Racer 8-bit road drawing, shared between the TICI and MICI model renderers.
+
+Extracted verbatim from selfdrive/ui/bp/onroad/model_renderer_bp.py so the comma four
+(MICI) renderer can reuse the exact same green game road without duplicating it. The
+mixin only touches the attribute contract both ModelRenderer families share:
+_road_edges, _road_edge_stds, _lane_lines, _lane_line_probs, _path, _rect,
+_map_to_screen, and the host-managed _dash_phase (advanced with vEgo by the host class).
+"""
+import numpy as np
+import pyray as rl
+
+from openpilot.selfdrive.ui.onroad.model_renderer import MAX_DRAW_DISTANCE
+from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
+from openpilot.system.ui.lib.shader_polygon import draw_polygon
+
+RAD_RACER_ROAD_EDGE_WIDTH = 0.24       # solid outer lines (meters, half-width)
+RAD_RACER_DASH_HALF_WIDTH = 0.09       # dashed lane line quad half-width (meters)
+RAD_RACER_DASH_LEN_M = 4.0
+RAD_RACER_GAP_LEN_M = 4.0
+RAD_RACER_CURB_LEN_M = 3.0             # length of each red/white curb block (meters)
+RAD_RACER_GREEN = rl.Color(72, 216, 0, 255)
+RAD_RACER_DIM = rl.Color(110, 110, 110, 255)  # road color when disengaged
+RAD_RACER_PATH_SHADE = rl.Color(150, 255, 120, 110)      # planned path fill when engaged
+RAD_RACER_PATH_SHADE_DIM = rl.Color(120, 120, 120, 80)   # planned path fill when disengaged
+RAD_RACER_CURB_RED = rl.Color(255, 48, 48, 255)
+RAD_RACER_CURB_WHITE = rl.Color(255, 255, 255, 255)
+
+
+class RadRacerRoadMixin:
+  """8-bit road rendering for ModelRenderer subclasses (see module docstring)."""
+
+  def _rad_racer_road_color(self) -> rl.Color:
+    """Green when lateral control is engaged, dim gray otherwise (safety cue)."""
+    if ui_state.status in (UIStatus.ENGAGED, UIStatus.OVERRIDE):
+      return RAD_RACER_GREEN
+    return RAD_RACER_DIM
+
+  def _draw_rad_racer_road(self):
+    """8-bit road: red/white curbs, light green planned path ribbon, dashed lane lines."""
+    color = self._rad_racer_road_color()
+
+    # Race-track curbs on the outer road edges
+    for i, road_edge in enumerate(self._road_edges):
+      if road_edge.raw_points.shape[0] < 2:
+        continue
+      edge_alpha = np.clip(1.0 - self._road_edge_stds[i], 0.3, 1.0)
+      self._draw_curbed_line(road_edge.raw_points, RAD_RACER_ROAD_EDGE_WIDTH, edge_alpha)
+
+    # Planned path ribbon — shaded fill so it reads clearly vs dashed lane lines
+    if self._path.projected_points.size > 0:
+      engaged = ui_state.status in (UIStatus.ENGAGED, UIStatus.OVERRIDE)
+      shade = RAD_RACER_PATH_SHADE if engaged else RAD_RACER_PATH_SHADE_DIM
+      draw_polygon(self._rect, self._path.projected_points, shade)
+
+    # Dashed lane lines
+    for i, lane_line in enumerate(self._lane_lines):
+      if self._lane_line_probs[i] < 0.4:
+        continue
+      self._draw_dashed_line(lane_line.raw_points, RAD_RACER_DASH_HALF_WIDTH, color, z_off=0.0)
+
+  def _draw_curbed_line(self, raw_points: np.ndarray, half_width: float, alpha: float = 1.0, z_off: float = 0.0):
+    """Draw a polyline as solid alternating red/white curb blocks (race-track edge)."""
+    if raw_points.shape[0] < 2:
+      return
+
+    xs = raw_points[:, 0]
+    x_min = max(float(xs[0]), 1.0)
+    x_max = min(float(xs[-1]), MAX_DRAW_DISTANCE)
+    if x_max <= x_min:
+      return
+
+    red = rl.Color(RAD_RACER_CURB_RED.r, RAD_RACER_CURB_RED.g, RAD_RACER_CURB_RED.b, int(255 * alpha))
+    white = rl.Color(RAD_RACER_CURB_WHITE.r, RAD_RACER_CURB_WHITE.g, RAD_RACER_CURB_WHITE.b, int(255 * alpha))
+    period = 2 * RAD_RACER_CURB_LEN_M
+    start = x_min - ((x_min + self._dash_phase) % period)
+    s = start
+    while s < x_max:
+      for offset, color in ((0.0, red), (RAD_RACER_CURB_LEN_M, white)):
+        x0 = max(s + offset, x_min)
+        x1 = min(s + offset + RAD_RACER_CURB_LEN_M, x_max)
+        if x1 <= x0:
+          continue
+        self._draw_road_ribbon_quad(raw_points, x0, x1, half_width, color, z_off)
+      s += period
+
+  def _draw_road_ribbon_quad(
+    self, raw_points: np.ndarray, x0: float, x1: float, half_width: float, color: rl.Color, z_off: float = 0.0,
+  ):
+    """Project one ribbon segment between x0 and x1 into screen space and fill it."""
+    xs = raw_points[:, 0]
+    y0 = float(np.interp(x0, xs, raw_points[:, 1]))
+    y1 = float(np.interp(x1, xs, raw_points[:, 1]))
+    z0 = float(np.interp(x0, xs, raw_points[:, 2])) + z_off
+    z1 = float(np.interp(x1, xs, raw_points[:, 2])) + z_off
+
+    p_near_l = self._map_to_screen(x0, y0 - half_width, z0)
+    p_near_r = self._map_to_screen(x0, y0 + half_width, z0)
+    p_far_r = self._map_to_screen(x1, y1 + half_width, z1)
+    p_far_l = self._map_to_screen(x1, y1 - half_width, z1)
+    if None in (p_near_l, p_near_r, p_far_r, p_far_l):
+      return
+
+    pts = [p_near_l, p_near_r, p_far_r, p_far_l]
+    area2 = sum(pts[i][0] * pts[(i + 1) % 4][1] - pts[(i + 1) % 4][0] * pts[i][1] for i in range(4))
+    if area2 > 0:
+      pts.reverse()
+    quad = [rl.Vector2(p[0], p[1]) for p in pts]
+    rl.draw_triangle_fan(quad, len(quad), color)
+
+  def _draw_dashed_line(self, raw_points: np.ndarray, half_width: float, color: rl.Color, z_off: float = 0.0):
+    """Draw a polyline as chunky scrolling dashes. Each dash is one projected quad."""
+    if raw_points.shape[0] < 2:
+      return
+
+    xs = raw_points[:, 0]
+    x_min = max(float(xs[0]), 1.0)
+    x_max = min(float(xs[-1]), MAX_DRAW_DISTANCE)
+    if x_max <= x_min:
+      return
+
+    period = RAD_RACER_DASH_LEN_M + RAD_RACER_GAP_LEN_M
+    # Dashes scroll toward the viewer as the car moves (phase advances with distance traveled)
+    start = x_min - ((x_min + self._dash_phase) % period)
+    s = start
+    while s < x_max:
+      x0 = max(s, x_min)
+      x1 = min(s + RAD_RACER_DASH_LEN_M, x_max)
+      s += period
+      if x1 <= x0:
+        continue
+      self._draw_road_ribbon_quad(raw_points, x0, x1, half_width, color, z_off)

--- a/selfdrive/ui/bp/onroad/rad_racer_theme.py
+++ b/selfdrive/ui/bp/onroad/rad_racer_theme.py
@@ -27,21 +27,15 @@ DM_RESERVED_WIDTH = 250      # left inset for cluster label layout (legacy wedge
 DM_CLUSTER_GAP = 16          # clearance between DM widget and gauge cluster top
 
 # --- Scene ---
-SKYLINE_PX_SCALE = 4.2       # skyline texture pixel size on screen
 SKYLINE_PARALLAX = 0.55        # how much skyline shifts vs path center at the horizon
 SKYLINE_LOOKAHEAD_M = 150.0    # forward distance used to estimate road bend
 SKYLINE_OFFSET_SMOOTH = 0.14   # scroll smoothing (higher = snappier)
-SKYLINE_MAX_OFFSET = 420.0    # clamp skyline travel in pixels
 STAR_PARALLAX = 0.22           # stars drift slightly with the skyline
-STAR_COUNT = 28
 SIGN_SPACING_M = 55.0        # distance between consecutive roadside signs
 SIGN_MIN_M = 7.0             # respawn signs once they pass this distance
 SIGN_MAX_M = SIGN_MIN_M + 3 * SIGN_SPACING_M
 SIGN_LATERAL_M = 7.5         # lateral offset from path center, alternating sides
 SIGN_TOP_Z = 4.2             # sign face top height in meters
-EGO_CAR_PX = 9.0             # ego sprite pixel scale
-EGO_CLUSTER_PAD = 6          # gap between ego sprite bottom and gauge cluster top
-LEAD_EGO_GAP = 14            # min gap between lead sprite bottom and ego sprite top
 LEAD_MAX_DRAW_M = 120.0
 
 # --- Cluster bar geometry ---
@@ -57,7 +51,19 @@ BOX_BORDER = rl.Color(20, 10, 40, 255)
 
 
 class RadRacerTheme:
-  """Renders the 8-bit racing scene. Textures are built lazily on first render."""
+  """Renders the 8-bit racing scene. Textures are built lazily on first render.
+
+  Screen-scale knobs live as class attributes (TICI 2160x1080 values here) so device
+  variants can subclass and rescale — see RadRacerThemeMici for the comma four.
+  """
+
+  SKYLINE_PX_SCALE = 4.2       # skyline texture pixel size on screen
+  SKYLINE_MAX_OFFSET = 420.0   # clamp skyline travel in pixels
+  STAR_COUNT = 28
+  EGO_CAR_PX = 9.0             # ego sprite pixel scale
+  EGO_CLUSTER_PAD = 6          # gap between ego sprite bottom and gauge cluster top
+  LEAD_EGO_GAP = 14            # min gap between lead sprite bottom and ego sprite top
+  LEAD_SPRITE_PX = (10.0, 5.0, 2.0)  # lead sprite pixel scale at dRel 5/40/100 m
 
   def __init__(self):
     self._loaded = False
@@ -85,7 +91,7 @@ class RadRacerTheme:
     self._skyline_tex = assets.build_skyline_texture()
     import random
     rng = random.Random(7)
-    self._stars = [(rng.random(), rng.random(), rng.randint(2, 4)) for _ in range(STAR_COUNT)]
+    self._stars = [(rng.random(), rng.random(), rng.randint(2, 4)) for _ in range(self.STAR_COUNT)]
     self._loaded = True
 
   # ------------------------------------------------------------------
@@ -99,7 +105,7 @@ class RadRacerTheme:
     skyline_scroll = self._update_skyline_scroll(rect, model_renderer)
 
     # Star field in the sky band (subtle parallax with the skyline)
-    sky_h = max(1.0, horizon_y - rect.y - SKYLINE_PX_SCALE * self._skyline_tex.height)
+    sky_h = max(1.0, horizon_y - rect.y - self.SKYLINE_PX_SCALE * self._skyline_tex.height)
     star_shift = skyline_scroll * STAR_PARALLAX
     for fx, fy, size in self._stars:
       sx = rect.x + fx * rect.width + star_shift
@@ -108,12 +114,12 @@ class RadRacerTheme:
       rl.draw_rectangle(int(sx), int(sy), size, size, color)
 
     # City skyline, bottom-aligned to the horizon, tiled with curvature parallax
-    sky_w = self._skyline_tex.width * SKYLINE_PX_SCALE
-    sky_hh = self._skyline_tex.height * SKYLINE_PX_SCALE
+    sky_w = self._skyline_tex.width * self.SKYLINE_PX_SCALE
+    sky_hh = self._skyline_tex.height * self.SKYLINE_PX_SCALE
     x = rect.x - (skyline_scroll % sky_w)
     while x < rect.x + rect.width:
       w = min(sky_w, rect.x + rect.width - x)
-      src = rl.Rectangle(0, 0, w / SKYLINE_PX_SCALE, self._skyline_tex.height)
+      src = rl.Rectangle(0, 0, w / self.SKYLINE_PX_SCALE, self._skyline_tex.height)
       dst = rl.Rectangle(x, horizon_y - sky_hh, w, sky_hh)
       rl.draw_texture_pro(self._skyline_tex, src, dst, rl.Vector2(0, 0), 0.0, rl.WHITE)
       x += sky_w
@@ -139,7 +145,7 @@ class RadRacerTheme:
 
     center_x = rect.x + rect.width / 2
     # Path center left of screen -> scroll skyline right (classic horizon parallax)
-    target = float(np.clip((center_x - pt[0]) * SKYLINE_PARALLAX, -SKYLINE_MAX_OFFSET, SKYLINE_MAX_OFFSET))
+    target = float(np.clip((center_x - pt[0]) * SKYLINE_PARALLAX, -self.SKYLINE_MAX_OFFSET, self.SKYLINE_MAX_OFFSET))
     self._skyline_scroll += SKYLINE_OFFSET_SMOOTH * (target - self._skyline_scroll)
     return self._skyline_scroll
 
@@ -219,13 +225,13 @@ class RadRacerTheme:
   def render_foreground(self, rect: rl.Rectangle, model_renderer, cluster_top: float):
     self._ensure_loaded()
 
-    ego_w = self._ego_tex.width * EGO_CAR_PX
-    ego_h = self._ego_tex.height * EGO_CAR_PX
+    ego_w = self._ego_tex.width * self.EGO_CAR_PX
+    ego_h = self._ego_tex.height * self.EGO_CAR_PX
     ego_cx = self._ego_path_center_x(model_renderer)
     if ego_cx is None:
       ego_cx = rect.x + rect.width / 2
-    ego_top = cluster_top - ego_h - EGO_CLUSTER_PAD
-    max_lead_bottom = ego_top - LEAD_EGO_GAP
+    ego_top = cluster_top - ego_h - self.EGO_CLUSTER_PAD
+    max_lead_bottom = ego_top - self.LEAD_EGO_GAP
 
     # Ego car first so lead sprites always paint on top when close
     ego_src = rl.Rectangle(0, 0, self._ego_tex.width, self._ego_tex.height)
@@ -246,7 +252,7 @@ class RadRacerTheme:
         cx = lv.chevron[1][0]
         # Anchor lead bottom to chevron base, but never below the ego car icon
         base_y = min(float(lv.chevron[0][1]), max_lead_bottom)
-        px = float(np.interp(lead.dRel, [5.0, 40.0, 100.0], [10.0, 5.0, 2.0]))
+        px = float(np.interp(lead.dRel, [5.0, 40.0, 100.0], self.LEAD_SPRITE_PX))
         tex = self._lead_tex[i]
         w, h = tex.width * px, tex.height * px
         src = rl.Rectangle(0, 0, tex.width, tex.height)


### PR DESCRIPTION
Brings the BPRadRacerTheme onroad scene (black sky, star field, parallax skyline, roadside signs, green game road with red/white curbs and scrolling dashes, ego + lead car sprites) to the 536x240 MICI display, with an on/off toggle ("8-Bit Racer Theme") in the MICI visuals settings. Param default is off; with the toggle off every renderer follows its existing code path unchanged.

Structure:
- The road-drawing methods and constants move verbatim from the TICI ModelRendererBP into a shared RadRacerRoadMixin (rad_racer_road.py); the TICI class now inherits the mixin. No TICI value or behavior changes.
- RadRacerTheme's screen-scale knobs (skyline scale, star count, sprite scales, gaps) become class attributes -- TICI values unchanged -- so RadRacerThemeMici can subclass with ~0.25x MICI scales.
- No gauge cluster on MICI: at 240 px tall it would cover the whole screen, and the MICI HUD/complication already shows that data. The ego sprite anchors to the bottom edge instead.
- MICI wiring mirrors TICI: camera blacks out via the shared _should_hide_camera_view gate, background renders after the camera and before the model road, sprites render after; params cached and refreshed on the existing ~1 s cadences.

Known MICI-specific behavior: the base MICI renderer skips all road drawing while DISENGAGED, so the theme shows sky + ego only until engagement (TICI shows a dim gray road); consistent with MICI's existing minimal-view behavior.