### PR TITLE
sunnylink: regenerate settings_ui.json (restores the Ford pinion toggle)

### DIFF
--- a/sunnypilot/sunnylink/settings_ui.json
+++ b/sunnypilot/sunnylink/settings_ui.json
@@ -2123,6 +2123,13 @@
           "needs_onroad_cycle": true,
           "title": "[Vehicle] Use Pinion Yaw Sensor",
           "description": "Measures how the car is turning from the steering pinion angle sensor instead of the RCM yaw sensor, in both the control software and the panda safety firmware. Use this if your Ford has a faulty yaw sensor: frequent \"Turn Exceeds Steering Limit\" warnings and weak curve tracking with healthy steering, often alongside \"Service AdvanceTrac\" messages. Run tools/ford_yaw_health_check.py on a few drives to check. Takes effect the next time the car starts. Not available on the Edge (its pinion sensor only reports a relative angle).",
+          "enablement": [
+            {
+              "type": "offroad_only"
+            }
+          ]
+        },
+        {
           "key": "BPUseCustomSounds",
           "widget": "toggle",
           "needs_onroad_cycle": true,


### PR DESCRIPTION
# sunnylink: regenerate settings_ui.json (restores the Ford pinion toggle)

The bp-dev merge in #145 hand-resolved the `settings_ui.json` conflict and fused two
adjacent toggle objects into one. The feature itself merged correctly — only its remote
settings entry disappeared. This regenerates the file from its source.

## The evidence that motivated this

`settings_ui.json` on current bp-dev contains this (abridged):

```json
{
  "key": "FordPrefSteerAngleCurvature",
  "title": "[Vehicle] Use Pinion Yaw Sensor",
  "description": "...",
  "key": "BPUseCustomSounds",          <-- second key, same object
  "title": "[Audio] Use Custom Engage/Disengage Sounds",
  "enablement": [{ "type": "offroad_only" }]
}
```

`FordPrefSteerAngleCurvature` opened an object, then `BPUseCustomSounds`' keys were
appended into that same object instead of starting a new one. JSON permits duplicate
keys and the last one wins, so:

- the file still parses,
- it still greps as containing both toggle names,
- but once parsed, **the pinion toggle is gone** from the sunnylink settings UI, and it
  took its `offroad_only` enablement with it.

That combination is why it survived review: every cheap check passes. It only shows up
when you parse the file and look for the key, or when you run the compiler in `--check`
mode.

Confirming on current bp-dev:

```
FordPrefSteerAngleCurvature: MISSING
BPUseCustomSounds:           PRESENT
```

## Why the fix is shaped this way

`settings_ui.json` is a generated artifact — `sunnypilot/sunnylink/tools/compile_settings_ui.py`
emits it from the authoring tree in `settings_ui_src/`. The YAML source
(`settings_ui_src/pages/vehicle.yaml`) was resolved correctly during the merge and still
holds both toggles as separate, complete entries.

So this is not a hand-patch of the JSON. It is one run of the compiler, committing what
it emits. Hand-editing generated output is what produced the bug in the first place.

## The evidence afterwards

- `tools/compile_settings_ui.py --check` reports a match. Before this commit it reported
  `differs from compiled output`.
- `sunnypilot/sunnylink/tests/` goes from **2 failed / 75 passed** to
  **77 passed / 1 skipped**. The two failures were
  `TestRoundtrip::test_committed_file_is_canonical` and
  `TestSchemaCoverage::test_all_schema_keys_exist_in_params`.
- Parsing the result finds all three toggles with their enablement intact:
  `FordPrefSteerAngleCurvature` → `[offroad_only]`, `BPUseCustomSounds` →
  `[offroad_only]`, `BPCustSoundsSelection` → `[offroad_only, param BPUseCustomSounds]`.
- The diff is +7 lines: the closing brace, enablement block, and opening brace that
  separate the two objects. No content is added or removed.

## What each change is

One commit, one generated file. No source, schema, or behaviour changes.

## Test it yourself

```bash
# before this PR this reports "differs from compiled output"
python sunnypilot/sunnylink/tools/compile_settings_ui.py --check

pytest sunnypilot/sunnylink/tests/ -n0

# the direct check: is the toggle actually there once parsed?
python -c "
import json
d = json.load(open('sunnypilot/sunnylink/settings_ui.json'))
def walk(o):
    if isinstance(o, dict):
        if isinstance(o.get('key'), str): yield o['key']
        for v in o.values(): yield from walk(v)
    elif isinstance(o, list):
        for v in o: yield from walk(v)
print('FordPrefSteerAngleCurvature' in list(walk(d)))
"
```

## Risks / limits

- Generated-file-only change; nothing else moves.
- Unrelated pre-existing issue, deliberately left alone: `validate_settings_ui.py` still
  reports `duplicate keys: 'BlinkerMinLateralControlSpeed' in [steering,
  vehicle_settings.ford]`. That key is declared in both `steering.yaml` and
  `vehicle.yaml` on stock bp-dev and predates this work — worth a separate fix.
- Worth considering separately: a CI step running `compile_settings_ui.py --check` would
  have caught this at the merge, since the failure mode is invisible to review.
