### PR TITLE
Ford: extend the angle-mode stall rescue below 9 m/s with the pinion measurement

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -102,6 +102,11 @@ _PSCM_SAT_UNWIND_RATE = 0.02        # rad/call (0.02 * 20Hz = 0.40 rad/s)
 _STEER_DT = CarControllerParams.STEER_STEP * DT_CTRL  # 20 Hz lateral tick (matches human_turn.py)
 _STALL_GAP_MIN = 2.0 * CarControllerParams.CURVATURE_ERROR  # desired must lead measured by 2x the clip tolerance
 _STALL_HOLD_S = 0.5          # accumulated clip-binding time before a pulse fires
+_DEVIATION_CLIP_GATE_MS = 9.0  # m/s; below this the deviation clip (and stall detection on yaw) is inert
+# With the pinion measurement the geometric source is trustworthy at low speed (best there, in
+# fact), so stall detection can extend to the path-offset check's low-speed floor (5 m/s,
+# ford.h FORD_PATH_OFFSET_LIMITS.angle_error_min_speed). On yaw the 9 m/s distrust stands.
+_STALL_GATE_PINION_MS = 5.0
 _STALL_BLIP_FRAMES = 6       # mode-0 pulse length (6 frames @ 20 Hz = 300 ms; PSCM acked mode 0 in ~150 ms on-road)
 _STALL_COOLDOWN_S = 2.0      # re-arm delay after a pulse (release ramp + PSCM response time)
 _STALL_MAX_BLIPS = 3         # give up on a stuck episode; devLim telemetry keeps recording the stall
@@ -428,9 +433,9 @@ class LateralAngleExt:
     # Use planner / predicted κ directly for the κ → path_angle map; we are not sending κ on CAN.
     kappa_cmd = float(requested_curvature)
 
-    # BluePilot: clip kappa_cmd to current_curvature (measured, from yaw rate) +- CURVATURE_ERROR,
+    # BluePilot: clip kappa_cmd to current_curvature (measured, via get_current_curvature) +- CURVATURE_ERROR,
     # mirroring lateral_curv_ext.py's apply_ford_curvature_limits_ext exactly (same formula, same
-    # v_ego > 9 gate, same CarControllerParams.CURVATURE_ERROR tolerance). Without this, kappa_cmd
+    # _DEVIATION_CLIP_GATE_MS gate, same CarControllerParams.CURVATURE_ERROR tolerance). Without this, kappa_cmd
     # (and therefore path_angle, and the shadow_curvature sent to ford.h) can legitimately lead the
     # measured curvature by more than ford.h's angle-error tolerance during normal curve entry/exit
     # -- the shadow-curvature deviation check (ford_shadow_curvature_error_check) would then block
@@ -439,7 +444,7 @@ class LateralAngleExt:
     # than only clipping the value reported to panda (which would make the check a no-op).
     current_curvature = self.get_current_curvature(CS)
     self.bp_curvature_deviation_limited = False
-    if v_ego > 9:
+    if v_ego > _DEVIATION_CLIP_GATE_MS:
       _kappa_cmd_pre_error_clip = kappa_cmd
       kappa_cmd = float(clip(kappa_cmd, current_curvature - CarControllerParams.CURVATURE_ERROR,
                             current_curvature + CarControllerParams.CURVATURE_ERROR))
@@ -536,13 +541,20 @@ class LateralAngleExt:
     # clip's tolerance while the clip was actually binding for _STALL_HOLD_S accumulated seconds.
     # devLim flickers mid-stall (~63% duty on the diagnosis route), so off frames hold the
     # accumulator rather than resetting it; a closed gap or driver press ends the episode.
+    # With the pinion measurement, detection extends below the deviation clip's own gate
+    # (see _STALL_GATE_PINION_MS): there the clip can never bind, so the accumulator charges on
+    # the raw gap instead -- observed on-road as a post-override PSCM stall through an entire
+    # ~60 m-radius turn at 19 mph that the current gating could never rescue.
     self.stall_blip_cooldown_s = max(0.0, self.stall_blip_cooldown_s - _STEER_DT)
+    _stall_gate_ms = _STALL_GATE_PINION_MS if self.bp_pinion_curvature_enabled else _DEVIATION_CLIP_GATE_MS
     _stall_gap = desired_curvature - current_curvature
-    _stalled = (not CS.out.steeringPressed and not self.lane_change and v_ego > 9.0
+    _stalled = (not CS.out.steeringPressed and not self.lane_change and v_ego > _stall_gate_ms
                 and abs(_stall_gap) > _STALL_GAP_MIN
                 and abs(desired_curvature) > abs(current_curvature))
     if _stalled:
-      if self.bp_curvature_deviation_limited and self.stall_blip_cooldown_s <= 0.0:
+      _clip_can_bind = v_ego > _DEVIATION_CLIP_GATE_MS
+      _charging = self.bp_curvature_deviation_limited or (self.bp_pinion_curvature_enabled and not _clip_can_bind)
+      if _charging and self.stall_blip_cooldown_s <= 0.0:
         self.stall_blip_hold_s += _STEER_DT
       if self.stall_blip_hold_s >= _STALL_HOLD_S and self.stall_blip_count < _STALL_MAX_BLIPS:
         self.stall_blip_frames_left = _STALL_BLIP_FRAMES

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lateral_angle_ext.py
@@ -202,5 +202,36 @@ class TestInitializeFord(unittest.TestCase):
     self.assertIs(type(CP_SP.safetyParam), int)
 
 
+class TestLowSpeedStallRescue(unittest.TestCase):
+  """With the pinion measurement enabled, stall detection extends below the deviation
+  clip's 9 m/s gate (down to 5 m/s, the ford.h path-offset floor), charging on the raw
+  gap where the clip can never bind. With the flag off, gating is bit-identical to
+  before: nothing charges below 9 m/s (yaw measurement distrust stands)."""
+
+  def _drive_stalled(self, ext, CP, v_ego, frames):
+    # hands-off, measured curvature 0 (wheel straight), planner asking 0.01 -> raw gap
+    # 0.01 > _STALL_GAP_MIN; below 9 m/s the deviation clip is inert so devLim stays False
+    cs = _CS(vEgoRaw=v_ego, vEgo=v_ego, yawRate=0.0, steeringAngleDeg=0.0)
+    for _ in range(frames):
+      ext.update_angle_strategy(_CC(latActive=True), cs, _Actuators(curvature=0.01), CP)
+
+  def test_pinion_rescues_below_clip_gate(self):
+    ext, CP = _pinion_harness(flag=True)
+    self._drive_stalled(ext, CP, v_ego=6.0, frames=12)
+    self.assertEqual(ext.stall_blip_count, 1)  # blip fired from gap-only accumulation
+
+  def test_pinion_inert_below_stall_gate(self):
+    ext, CP = _pinion_harness(flag=True)
+    self._drive_stalled(ext, CP, v_ego=4.5, frames=12)
+    self.assertEqual(ext.stall_blip_count, 0)
+    self.assertEqual(ext.stall_blip_hold_s, 0.0)
+
+  def test_yaw_mode_unchanged_below_gate(self):
+    ext, CP = _pinion_harness(flag=False)
+    self._drive_stalled(ext, CP, v_ego=6.0, frames=12)
+    self.assertEqual(ext.stall_blip_count, 0)
+    self.assertEqual(ext.stall_blip_hold_s, 0.0)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
# Ford: extend the angle-mode stall rescue below 9 m/s with the pinion measurement

The post-override stall-rescue pulse is gated above 9 m/s **and** on the deviation clip
actually binding. Both conditions exist because the yaw-derived measurement is untrustworthy
at low speed. With the pinion measurement enabled (#145, merged) neither reason holds — the
geometric measurement is at its most accurate exactly there — and the current predicate
structurally cannot fire below the gate.

Flag off, gating is bit-identical to today. This was previously part of #145 and was split
out so the measurement feature could be reviewed on its own.

## The evidence that motivated this

Route `00000018--9b********`, a low-speed drive: silent lane-exit understeer under 10 mph,
delivery falling from 0.42 toward ~0 as speed dropped, with no alert raised.

The stall detector could never have rescued it, and not because of tuning. The predicate is:

```python
_stalled = (... and v_ego > 9.0 and abs(_stall_gap) > _STALL_GAP_MIN ...)
if _stalled:
  if self.bp_curvature_deviation_limited and self.stall_blip_cooldown_s <= 0.0:
    self.stall_blip_hold_s += _STEER_DT
```

`bp_curvature_deviation_limited` is set only inside `if v_ego > 9:` — the deviation clip's
own gate. So below 9 m/s the clip never runs, its flag can never set, and the accumulator
can never charge. The `v_ego > 9.0` term makes that unreachable anyway. The two gates are
the same threshold twice, and between them the low-speed case is a dead branch: replaying
route 18's stalled turn, the old gating never fires at any point.

## Why the fix is shaped this way

Two changes, both behind `bp_pinion_curvature_enabled`:

- **The stall gate drops to 5 m/s**, not to zero. 5.0 is not a new number — it is
  `FORD_PATH_OFFSET_LIMITS.angle_error_min_speed`, the low-speed floor ford.h already uses
  for the path-offset check. Reusing the existing floor keeps one notion of "too slow to
  reason about steering geometry" instead of inventing a second.
- **Below the clip's gate the accumulator charges on the raw desired-vs-measured gap**
  instead of on the clip's flag, because there the clip provably cannot bind. Above the
  gate, charging is unchanged and still keyed to the clip.

The bare `9` literals became `_DEVIATION_CLIP_GATE_MS`, so the coupling between the clip's
gate and the detector's gate is visible rather than implied by two matching magic numbers.

Nothing here widens *when* a pulse is allowed to fire in the yaw case, and nothing changes
the pulse itself.

## The evidence afterwards

- **Replay of route 18's stalled turn**: the old gating never fires; the new gating fires
  during the stall, ahead of the driver's intervention.
- **Flag off is bit-identical**: nothing charges below 9 m/s, unit-tested directly rather
  than argued.
- **Route `00000021--2e1a********`** (a dedicated low-speed drive taken to characterise this
  region) shows the honest limit of the approach — see Risks below.

**On-road since opening** (update): route `00000027--97********` produced a clean
low-speed rescue at 16 mph — delivery recovered to 0.96 after the pulse — exactly the
episode class this extension exists for. Context worth having for review: the low-speed
authority derate has since been root-caused to the PSCM's own availability policy
(broadcast on CAN 972, `LaActAvail_D_Actl`: a hard ~40 km/h line — see #155). The pulse
cures the press-attenuation component that stacks on top of that policy, not the policy
itself, which matches both this route's success and route 21's honest-limit episodes. A
follow-up (after this lands) gates the pulse on that broadcast so purely policy-bound
deficits stop spending futile 300 ms releases.

## What each change is

One commit touching two files: the gate/charging change in `lateral_angle_ext.py`, and
`TestLowSpeedStallRescue` in the Ford ext tests — pinion-on rescues below the clip gate,
pinion-on stays inert below 5 m/s, and yaw mode is unchanged below the gate.

## Test it yourself

```bash
pytest opendbc_repo/opendbc/sunnypilot/car/ford/tests/ -n0
```

On a car with **Use Pinion Yaw Sensor** enabled: after a manual correction at low speed,
expect a brief steering release-and-retake pulse instead of a frozen wheel.

## Risks / limits

- **Land #148 first.** This increases exposure to the detector's *existing* arming
  condition (absolute gap only), which route `0000001e--be********` showed also fires on
  honest deep-curve entry transients. #148 replaces that trigger with a fractional delivery
  deficit (< 0.65×) and was replay-validated jointly with this change. Merged in the other
  order, this widens a known-imperfect trigger into a new speed range.
- **Not yet road-validated on this exact commit.** The replay evidence is solid, but the
  acceptance drive predates the current tip; treat the on-road behaviour as unproven.
- **A pulse does not fix everything down here.** Route 21 measured a speed-dependent PSCM
  *authority derate* — experienced delivery ~0.16/0.23/0.47/0.71/0.75 at
  1–2.5/2.5–4/4–5.5/5.5–7/7–9 m/s — that coexists with post-press attenuation. A reset pulse
  addresses only the attenuation, so post-pulse improvement in this band is mixed rather
  than uniform. Below roughly 4 m/s the derate looks like a firmware authority wall that no
  amount of gating or gain can recover; this change is aimed at the 5–9 m/s band where a
  stalled PSCM genuinely can be released.
- Flag off: no behaviour change (unit-tested).

