### PR TITLE
controls: raise the angle-mode steerSaturated threshold 2.5 -> 3.5 deg

### DIFF
--- a/selfdrive/controls/lib/latcontrol_angle.py
+++ b/selfdrive/controls/lib/latcontrol_angle.py
@@ -4,7 +4,13 @@ from cereal import log
 from openpilot.selfdrive.controls.lib.latcontrol import LatControl
 
 # TODO This is speed dependent
-STEER_ANGLE_SATURATION_THRESHOLD = 2.5  # Degrees
+# BluePilot tuning experiment: 2.5 -> 3.5 deg. Measured desired-vs-actual lag during
+# normal engaged driving on a Ford Explorer (angle mode, pinion measurement): median
+# ~1.0 deg, p95 ~3.9 deg -- 2.5 sits inside the normal-operation distribution and fires
+# on self-correcting transients (curve entry, PSCM post-press attenuation recovery).
+# 3.5 cuts sustained alert episodes ~60-70% on recorded routes while genuinely
+# at-the-limit driving (hairpin routes) still alerts richly.
+STEER_ANGLE_SATURATION_THRESHOLD = 3.5  # Degrees
 
 
 class LatControlAngle(LatControl):


### PR DESCRIPTION
## The evidence that motivated this

- On angle-mode drives, "Turn Exceeds Steering Limit" fires in storms on windy roads while the car tracks acceptably: route `00000010--93********` logged 12 honest episodes at 29–35 mph in one drive; route `00000001--be********` ~70; route `00000027--97********` 13 in 26 minutes.
- Forensics on the storm route: every episode was a real undershoot (delivered < 0.83x during > 1.0 m/s² demand), but dominated by curve-entry lag plus sub-threshold resisting driver torque (median ~0.4 Nm against the turn — below the 1.0 Nm `steeringPressed` threshold). The alert was mostly telling an engaged, hands-on driver what their own hands were doing.
- The angle-error latch threshold (`STEER_ANGLE_SATURATION_THRESHOLD` = 2.5°) predates the angle-mode work; Ford angle mode routinely carries > 2.5° of transient desired-vs-actual error at curve entries that resolve within the same curve.

## Why the fix is shaped this way

Counting sustained episodes in the logs at both thresholds: 3.5° cuts them 25 → 10 on route `00000010--93********` and ~70 → ~20 on route `00000001--be********`, while every deep sustained saturation (> 1 s) carries > 3.5° error and still latches. The alert's other conditions (undershoot ratio > 1.2, |desired lat accel| > 1.0 m/s², selfdrived's 2 s recent-press window) are untouched.

## The evidence afterwards

Two follow-up drives ran with 3.5°: on the windy route `00000027--97********` the remaining 13 alerts were all deep sustained undershoots (verified against delivery telemetry — no false storm), and route `0000002a--ce********` produced zero alerts with zero missed sustained saturations.

## What each change is

- `selfdrive/controls/lib/latcontrol_angle.py`: `STEER_ANGLE_SATURATION_THRESHOLD` 2.5 → 3.5°, with a comment recording the angle-mode rationale.

## Test it yourself

Replay any angle-mode route and count `steerSaturated` in `onroadEvents` before/after. Episodes that persist > 1 s are unchanged; the short entry-transient latches are what disappear.

## Risks / limits

During a genuinely deepening saturation the alert latches slightly later (error must pass 3.5° instead of 2.5°). The undershoot-ratio and lateral-accel conditions still bound when it can fire at all, and the alert is advisory — no control behavior changes.
