### PR TITLE
Ford: parse the PSCM LatCtl status broadcast + opt-in hands-on context for steerSaturated

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -554,6 +554,7 @@ struct CarStateBP @0xb057204d7deadf3f {
   hybridDrive @0 :HybridDrive;
   hybridBattery @1 :HybridBattery;
   brakeLightStatus @2 :BrakeLightStatus;
+  pscmLatCtl @3 :PscmLatCtl;
 
   struct HybridDrive {
     dataAvailable @0 :Bool;
@@ -579,6 +580,15 @@ struct CarStateBP @0xb057204d7deadf3f {
   struct BrakeLightStatus {
     dataAvailable @0 :Bool;
     brakeLightsOn @1 :Bool;
+  }
+
+  # Ford PSCM lateral-control status broadcast (Lane_Assist_Data3_FD1)
+  struct PscmLatCtl {
+    dataAvailable @0 :Bool;
+    laActAvail @1 :UInt8;  # LaActAvail_D_Actl feature matrix: bit1 = LCA/LKA centering available, bit0 = LDW not suppressed; values 0/1 = centering policy-suppressed (Q3: below ~40 km/h)
+    laActDeny @2 :Bool;  # LaActDeny_B_Actl
+    laHandsOff @3 :Bool;  # LaHandsOff_B_Actl: PSCM hands-off estimate, more sensitive than steeringPressed
+    tjaHandsOnConfidence @4 :Bool;  # TjaHandsOnCnfdnc_B_Est
   }
 }
 

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -318,6 +318,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"vbatt_pause_charging", {PERSISTENT | BACKUP, FLOAT, "11.8"}},
     {"show_lead_speed", {PERSISTENT | BACKUP, BOOL, "1"}},
     {"FordPrefSteerAngleCurvature", {PERSISTENT | BACKUP, BOOL, "0"}},  // pinion-sourced curvature measurement (bad-yaw-sensor workaround); read at car init
+    {"FordPrefHideSteerSaturatedAlerts", {PERSISTENT | BACKUP, BOOL, "0"}},  // hide steerSaturated while the Ford PSCM reports hands-on; read by selfdrived
     {"FordPrefShowRadarLeadOverlay", {PERSISTENT | BACKUP, BOOL, "1"}},
     {"FordPrefRadarOverlaySize", {PERSISTENT | BACKUP, INT, "1"}},
     {"FordPrefHybridBatteryStatus", {PERSISTENT | BACKUP, BOOL, "0"}},

--- a/opendbc_repo/opendbc/car/ford/carstate.py
+++ b/opendbc_repo/opendbc/car/ford/carstate.py
@@ -225,6 +225,9 @@ class CarState(CarStateBase, MadsCarState, CarStateExt):
     else:
       pt_messages += [
         ("INSTRUMENT_PANEL", 1),
+        # BluePilot: PSCM LatCtl status telemetry — broadcast by CAN platforms too (measured 33Hz on
+        # Ford Q3), but presence isn't guaranteed fleet-wide, so keep it out of CAN validity
+        ("Lane_Assist_Data3_FD1", float('nan')),
       ]
 
     if CP.transmissionType == TransmissionType.automatic:

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/carstate_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/carstate_ext.py
@@ -90,6 +90,9 @@ class CarStateExt:
     self.cruise_enabled_prev = False
     # Track if mainCruise was pressed recently (to handle delayed cruise enable)
     self.main_cruise_pressed_recently = False
+    # Latches True once Lane_Assist_Data3_FD1 is seen — the message is non-critical in the
+    # parser, so cp.vl would otherwise report zeros on cars that never broadcast it
+    self.lane_assist_data3_seen = False
 
   def update(self, ret: structs.CarState, ret_sp: structs.CarStateSP, can_parsers: dict[StrEnum, CANParser]):
     """
@@ -339,6 +342,23 @@ class CarStateExt:
 
     brake_light_status.dataAvailable = False
     brake_light_status.brakeLightsOn = False
+
+    pscm_lat_ctl = dat.carStateBP.pscmLatCtl
+    pscm_lat_ctl.dataAvailable = False
+
+    # PSCM lateral-control status (Lane_Assist_Data3_FD1)
+    try:
+      if len(cp.vl_all["Lane_Assist_Data3_FD1"]["LaActAvail_D_Actl"]) > 0:
+        self.lane_assist_data3_seen = True
+      if self.lane_assist_data3_seen:
+        lad3 = cp.vl["Lane_Assist_Data3_FD1"]
+        pscm_lat_ctl.dataAvailable = True
+        pscm_lat_ctl.laActAvail = int(lad3["LaActAvail_D_Actl"])
+        pscm_lat_ctl.laActDeny = bool(lad3["LaActDeny_B_Actl"])
+        pscm_lat_ctl.laHandsOff = bool(lad3["LaHandsOff_B_Actl"])
+        pscm_lat_ctl.tjaHandsOnConfidence = bool(lad3["TjaHandsOnCnfdnc_B_Est"])
+    except (KeyError, AttributeError):
+      pass
 
     # Brake light status — try BCM message first, then fallback to BrakeSysFeatures_2
     brake_lights_detected = False

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -9,6 +9,7 @@ from cereal import car, log, custom
 from msgq.visionipc import VisionIpcClient, VisionStreamType
 
 
+from openpilot.common.bluepilot import is_bluepilot
 from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process, Priority, Ratekeeper, DT_CTRL
 from openpilot.common.swaglog import cloudlog
@@ -91,7 +92,10 @@ class SelfdriveD(CruiseHelper):
     # TODO: de-couple selfdrived with card/conflate on carState without introducing controls mismatches
     self.car_state_sock = messaging.sub_sock('carState', timeout=20)
 
-    ignore = self.sensor_packets + self.gps_packets + ['alertDebug', 'lateralManeuverPlan'] + ['modelDataV2SP']
+    # BluePilot: carStateBP is only published by brands whose carstate builds the message
+    # (Ford today), so it must never gate all_checks()/commIssue on other cars
+    ignore = self.sensor_packets + self.gps_packets + ['alertDebug', 'lateralManeuverPlan'] + ['modelDataV2SP'] \
+             + (['carStateBP'] if is_bluepilot() else [])
     if SIMULATION:
       ignore += ['driverCameraState', 'managerState']
     if REPLAY:
@@ -102,6 +106,7 @@ class SelfdriveD(CruiseHelper):
                                    'managerState', 'liveParameters', 'radarState', 'liveTorqueParameters',
                                    'controlsState', 'carControl', 'driverAssistance', 'alertDebug', 'userBookmark', 'audioFeedback',
                                    'lateralManeuverPlan', 'modelDataV2SP', 'longitudinalPlanSP'] + \
+                                   (['carStateBP'] if is_bluepilot() else []) + \
                                    self.camera_packets + self.sensor_packets + self.gps_packets,
                                   ignore_alive=ignore, ignore_avg_freq=ignore,
                                   ignore_valid=ignore, frequency=int(1/DT_CTRL))
@@ -110,6 +115,8 @@ class SelfdriveD(CruiseHelper):
     self.is_metric = self.params.get_bool("IsMetric")
     self.is_ldw_enabled = self.params.get_bool("IsLdwEnabled")
     self.disengage_on_accelerator = self.params.get_bool("DisengageOnAccelerator")
+    # BluePilot: hide steerSaturated while the EPS confirms hands on the wheel (Ford PSCM)
+    self.hide_steer_sat_hands_on = self.params.get_bool("FordPrefHideSteerSaturatedAlerts")
 
     car_recognized = self.CP.brand != 'mock'
 
@@ -444,7 +451,16 @@ class SelfdriveD(CruiseHelper):
       turning = abs(desired_lateral_accel) > 1.0
       # TODO: lac.saturated includes speed and other checks, should be pulled out
       if undershooting and turning and lac.saturated:
-        self.events.add(EventName.steerSaturated)
+        # BluePilot: the Ford PSCM's LaHandsOff broadcast detects hands at ~0.5 Nm where
+        # steeringPressed needs ~1.0 -- and those sub-threshold resisting hands both cause
+        # these episodes and prove the driver is already engaged with the wheel. Optionally
+        # hide the alert in exactly that case; if the EPS says hands-off, it always shows.
+        suppress = False
+        if self.hide_steer_sat_hands_on and 'carStateBP' in self.sm.data:
+          pscm = self.sm['carStateBP'].pscmLatCtl
+          suppress = pscm.dataAvailable and not pscm.laHandsOff
+        if not suppress:
+          self.events.add(EventName.steerSaturated)
 
     # Check for FCW
     stock_long_is_braking = self.enabled and not self.CP.openpilotLongitudinalControl and CS.aEgo < -1.25
@@ -620,6 +636,7 @@ class SelfdriveD(CruiseHelper):
       self.is_metric = self.params.get_bool("IsMetric")
       self.is_ldw_enabled = self.params.get_bool("IsLdwEnabled")
       self.disengage_on_accelerator = self.params.get_bool("DisengageOnAccelerator")
+      self.hide_steer_sat_hands_on = self.params.get_bool("FordPrefHideSteerSaturatedAlerts")
       self.experimental_mode = self.params.get_bool("ExperimentalMode") and self.CP.openpilotLongitudinalControl
       self.personality = self.params.get("LongitudinalPersonality", return_default=True)
 

--- a/selfdrive/ui/bp/layouts/settings/bluepilot.py
+++ b/selfdrive/ui/bp/layouts/settings/bluepilot.py
@@ -70,6 +70,7 @@ class BluePilotLayout(Widget):
     self._refresh_toggles = (
       ("send_hands_free_cluster_msg", self._show_hands_free_ui),
       ("FordPrefSteerAngleCurvature", self._steer_angle_curvature),
+      ("FordPrefHideSteerSaturatedAlerts", self._hide_steer_sat_alerts),
       ("BPDisableLaneLineStatusColor", self._disable_lane_line_status_color),
       ("BPHideCameraView", self._hide_camera_view),
       ("BPRadRacerTheme", self._rad_racer_theme),
@@ -118,6 +119,14 @@ class BluePilotLayout(Widget):
       lambda: tr('Measures how the car is turning from the steering pinion angle sensor instead of a faulty RCM yaw sensor (symptoms: "Turn Exceeds Steering Limit" warnings, weak curve tracking, "Service AdvanceTrac"). Check with tools/ford_yaw_health_check.py. Applies the next time the car starts. Not available on the Edge.'),
       initial_state=self._safe_get_bool(self._params, "FordPrefSteerAngleCurvature"),
       callback=lambda state: self._toggle_callback(state, "FordPrefSteerAngleCurvature"),
+      icon="monitoring.png"
+    )
+
+    self._hide_steer_sat_alerts = toggle_item(
+      lambda: tr("Hide Steering-Limit Alerts While Holding the Wheel"),
+      lambda: tr('Hides the "Turn Exceeds Steering Limit" warning only while the power steering itself reports your hands on the wheel. Light pressure against the turn usually triggers these warnings, and the steering rack detects that grip well below the pressure the driving software needs. If the rack reports hands-off, the warning always shows.'),
+      initial_state=self._safe_get_bool(self._params, "FordPrefHideSteerSaturatedAlerts"),
+      callback=lambda state: self._toggle_callback(state, "FordPrefHideSteerSaturatedAlerts"),
       icon="monitoring.png"
     )
 
@@ -655,6 +664,7 @@ class BluePilotLayout(Widget):
       _section(tr("Vehicle"), [
         self._show_hands_free_ui,
         self._steer_angle_curvature,
+        self._hide_steer_sat_alerts,
         self._vbatt_pause_charging,
       ]) +
       _section(tr("Audio"), [

--- a/selfdrive/ui/bp/mici/layouts/settings/vehicle_mici.py
+++ b/selfdrive/ui/bp/mici/layouts/settings/vehicle_mici.py
@@ -19,17 +19,20 @@ class VehicleLayoutMici(NavScroller):
     self.show_hands_free_ui = BigParamControlBP("Show BlueCruise UI on Cluster", "send_hands_free_cluster_msg")
     # Init-time param (read once at car init, mirrored into panda safety); takes effect after restart
     self.steer_angle_curvature = BigParamControlBP("Use Pinion Yaw Sensor", "FordPrefSteerAngleCurvature")
+    self.hide_steer_sat_alerts = BigParamControlBP("Hide Steer-Limit Alerts (Hands On)", "FordPrefHideSteerSaturatedAlerts")
     self.vbatt_pause_charging = BigParamFloatControl("12V Battery Limit", "vbatt_pause_charging", min=11.0, max=14.0, step=0.1)
 
     self._scroller.add_widgets([
       self.show_hands_free_ui,
       self.steer_angle_curvature,
+      self.hide_steer_sat_alerts,
       self.vbatt_pause_charging,
     ])
 
     self._refresh_toggles = (
       ("send_hands_free_cluster_msg", self.show_hands_free_ui),
       ("FordPrefSteerAngleCurvature", self.steer_angle_curvature),
+      ("FordPrefHideSteerSaturatedAlerts", self.hide_steer_sat_alerts),
     )
 
     ui_state.add_offroad_transition_callback(self._update_toggles)

--- a/sunnypilot/sunnylink/settings_ui.json
+++ b/sunnypilot/sunnylink/settings_ui.json
@@ -2130,6 +2130,12 @@
           ]
         },
         {
+          "key": "FordPrefHideSteerSaturatedAlerts",
+          "widget": "toggle",
+          "title": "[Vehicle] Hide Steering-Limit Alerts While Holding the Wheel",
+          "description": "Hides the \"Turn Exceeds Steering Limit\" warning only while the power steering itself reports your hands on the wheel. Light pressure against the turn is what usually triggers these warnings, and the steering rack detects that grip well below the pressure the driving software needs to notice it. If the steering rack reports hands-off, the warning always shows."
+        },
+        {
           "key": "BPUseCustomSounds",
           "widget": "toggle",
           "needs_onroad_cycle": true,

--- a/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
+++ b/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
@@ -57,6 +57,14 @@ sections:
       the Edge (its pinion sensor only reports a relative angle).'
     enablement:
     - $ref: '#/macros/offroad'
+  - key: FordPrefHideSteerSaturatedAlerts
+    widget: toggle
+    title: '[Vehicle] Hide Steering-Limit Alerts While Holding the Wheel'
+    description: 'Hides the "Turn Exceeds Steering Limit" warning only while the power
+      steering itself reports your hands on the wheel. Light pressure against the turn
+      is what usually triggers these warnings, and the steering rack detects that grip
+      well below the pressure the driving software needs to notice it. If the steering
+      rack reports hands-off, the warning always shows.'
   # --- Audio ---
   - key: BPUseCustomSounds
     widget: toggle


### PR DESCRIPTION
## The evidence that motivated this

- The Q3 PSCM broadcasts its own lateral-control status on `Lane_Assist_Data3_FD1` (CAN 972, 33 Hz) on CAN platforms too — openpilot only parses the message on CANFD, and only for a signal that is dead on Q3 (`LatCtlSte_D_Stat`).
- Mining five drives (`00000027--97********`, `00000010--93********`, `00000001--be********`, `00000002--71********`, `00000003--a1********`) found two live, load-bearing signals:
  - **`LaActAvail_D_Actl`** — the PSCM declares lateral actuation unavailable below a single sharp ~40 km/h line: 130 of 153 observed 0↔2 transitions sit at 24.2–25.0 mph in *both* directions, avail=0 covers 100% of sub-threshold frames on every route, and it reads 0 even while disengaged with nothing on the wire (it is the PSCM's own speed policy, not a reaction to commands). This is the root cause of the long-observed Q3 low-speed authority derate: below the line the PSCM serves LatCtl commands in a degraded best-effort regime. Per the DBC VAL_ table this is a feature matrix — bit1 = LCA/LKA centering available, bit0 = LDW not suppressed; states 1/3 are the LDW-available variants seen while active lateral control isn't running.
  - **`LaHandsOff_B_Actl`** — a graded hands-on detector ~2x more sensitive than `steeringPressed`: it flags hands at 0.5–1.0 Nm column torque in 82–93% of frames where `steeringPressed` fires 2–9%.
- steerSaturated storms on windy roads trace to sub-threshold resisting hands (delivery drops to ~0.95 vs ~0.99 for helping hands), and the PSCM's own hands bit confirms hands-on through most alert windows — the alert mostly tells a hands-on driver what their hands are doing.

## Why the fix is shaped this way

- **Telemetry first.** The message joins the parser as non-critical (`float('nan')` frequency, the `BCM_Lamp_Stat_FD1` pattern) with a seen-latch, so a Ford that doesn't broadcast it can never break CAN validity and `dataAvailable` stays honest.
- A global alternative — raising the steerSaturated angle-error threshold (#154) — was
  considered and withdrawn: it trades alert timing for every driver to address a cause
  specific to hands-on driving. This toggle addresses the cause directly and only for
  drivers who opt in.
- **The alert context is opt-in and conservative.** With the previously-unwired `FordPrefHideSteerSaturatedAlerts` toggle enabled, steerSaturated is hidden *only while the EPS itself reports hands on the wheel*; if the PSCM reports hands-off, the alert always shows. Default OFF — zero behavior change until opted in.
- `carStateBP` joins selfdrived's SubMaster **ignore lists**: only brands whose carstate builds the message publish it (Ford today), so it must never gate `all_checks()`/commIssue on other cars.
- The param is registered in `common/params_keys.h` — `bluepilot/params/params.json` alone is not consulted by `Params()`, and reading an unregistered key raises `UnknownKeyName` (found the hard way: selfdrived crash-looped on-device until this line existed).

## The evidence afterwards

Validation drive `0000002a--ce********` (8 segments): live-parsed values vs an independent raw-CAN bit decode of 972 = **0.00% mismatch on both signals over 41,714 samples**; live avail transitions at 24.6–24.9 mph, right on the 40 km/h line; `carStateBP` steady at 100 Hz; zero process crashes.

## What each change is

- `cereal/custom.capnp`: `CarStateBP.pscmLatCtl` (dataAvailable, laActAvail, laActDeny, laHandsOff, tjaHandsOnConfidence).
- `opendbc/car/ford/carstate.py`: `Lane_Assist_Data3_FD1` added to the non-CANFD parser list, non-critical.
- `opendbc/sunnypilot/car/ford/carstate_ext.py`: seen-latched populate of the new struct.
- `selfdrive/selfdrived/selfdrived.py`: SubMaster entry (ignore-listed) + the opt-in hands-on alert context.
- `common/params_keys.h`: register `FordPrefHideSteerSaturatedAlerts`.
- `settings_ui_src/pages/vehicle.yaml` + regenerated `settings_ui.json` (via `tools/compile_settings_ui.py`; `--check` clean): the toggle.
- `selfdrive/ui/bp/layouts/settings/bluepilot.py` + `mici/.../vehicle_mici.py`: the same toggle on the on-device vehicle settings (both surfaces, directly under the pinion toggle).

## Test it yourself

- Any Q3 CAN drive: `carStateBP.pscmLatCtl.laActAvail` flips 0↔2 crossing ~40 km/h; cross-check against raw CAN 972 (Motorola bits 5–4 of byte 0).
- Toggle OFF (default): no behavior difference anywhere.
- Toggle ON: steerSaturated appears only when the PSCM reports hands-off during the episode.

## Risks / limits

- Non-Ford cars: the message is never published; the ignore lists + seen-latch make the whole path inert (selfdrived tests green; process replay unaffected).
- The hands-on suppression can hide an honest saturation alert while the driver is physically holding the wheel — that is its purpose, it is opt-in, and hands-off alerts are never suppressed.
- `avail` consumers should key on bit1 (values 0/1 = centering policy-suppressed); bit0 only reflects LDW suppression.

