### PR TITLE
manager: re-sync the venv when the lockfile changes before building

### DIFF
--- a/system/manager/build.py
+++ b/system/manager/build.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import hashlib
 import os
+import shutil
 import subprocess
 
 # NOTE: Do NOT import anything here that needs be built (e.g. params)
@@ -8,6 +10,50 @@ from openpilot.common.spinner import Spinner
 from openpilot.common.text_window import TextWindow
 from openpilot.system.hardware import HARDWARE, AGNOS
 
+# The venv is provisioned once (at install) and persists across OTA updates, but nothing
+# reconciles it with the updated lockfile afterwards: updated.py only does a git fetch/reset.
+# When an update adds a Python dependency (e.g. acados), the stale venv is missing it and
+# scons dies importing it. Re-sync the venv whenever the checked-out uv.lock changes.
+UV_LOCK = os.path.join(BASEDIR, "uv.lock")
+SYNC_MARKER = os.path.join(BASEDIR, ".venv", ".op_synced_lock")
+
+
+def _uv_lock_digest() -> str | None:
+  try:
+    with open(UV_LOCK, "rb") as f:
+      return hashlib.sha256(f.read()).hexdigest()
+  except FileNotFoundError:
+    return None
+
+
+def sync_python_env() -> None:
+  # No-op unless uv.lock changed since the last successful sync. The marker lives inside
+  # the venv, so a wiped/recreated venv also re-syncs (its marker disappears with it).
+  digest = _uv_lock_digest()
+  if digest is None:
+    return
+
+  try:
+    with open(SYNC_MARKER) as f:
+      if f.read().strip() == digest:
+        return
+  except FileNotFoundError:
+    pass
+
+  uv = shutil.which("uv") or os.path.expanduser("~/.local/bin/uv")
+  if not os.path.exists(uv):
+    print("uv not found; skipping dependency sync")
+    return
+
+  # --frozen: install exactly what uv.lock pins, no re-resolution.
+  # --inexact: only add missing packages, never remove extras (won't clobber a dev's env).
+  subprocess.run([uv, "sync", "--frozen", "--inexact"], cwd=BASEDIR, check=True)
+
+  os.makedirs(os.path.dirname(SYNC_MARKER), exist_ok=True)
+  with open(SYNC_MARKER, "w") as f:
+    f.write(digest)
+
+
 def build() -> None:
   spinner = Spinner()
   spinner.update_progress(0, 100)
@@ -15,6 +61,17 @@ def build() -> None:
   HARDWARE.set_power_save(False)
   if AGNOS:
     os.sched_setaffinity(0, range(8))  # ensure we can use the isolcpus cores
+
+  # reconcile the venv with the checked-out lockfile before building
+  try:
+    sync_python_env()
+  except subprocess.CalledProcessError:
+    spinner.close()
+    if not os.getenv("CI"):
+      msg = "openpilot failed to update dependencies\n \nEnsure the device has an internet connection, then reboot."
+      with TextWindow(msg) as t:
+        t.wait_for_exit()
+    exit(1)
 
   # building with all cores can result in using too much memory, so retry serially
   compile_output: list[bytes] = []

--- a/system/manager/test/test_build.py
+++ b/system/manager/test/test_build.py
@@ -1,0 +1,57 @@
+import hashlib
+
+import openpilot.system.manager.build as build
+
+DIGEST_V1 = hashlib.sha256(b"lock-v1").hexdigest()
+
+
+class TestSyncPythonEnv:
+  """
+  Regression tests for the venv/lockfile reconciliation in build.py.
+
+  The venv is provisioned once at install and persists across OTA updates, but nothing
+  re-syncs it afterwards. When an update adds a Python dependency (e.g. acados), the stale
+  venv is missing it and scons dies importing it. sync_python_env() re-runs `uv sync`
+  whenever the checked-out uv.lock differs from what the venv was last synced against.
+  """
+
+  def _run(self, mocker, tmp_path, lock_bytes=b"lock-v1", marker_text=None, uv_found=True):
+    lock = tmp_path / "uv.lock"
+    if lock_bytes is not None:
+      lock.write_bytes(lock_bytes)
+    marker = tmp_path / ".venv" / ".op_synced_lock"
+    if marker_text is not None:
+      marker.parent.mkdir(parents=True, exist_ok=True)
+      marker.write_text(marker_text)
+
+    calls: list[list[str]] = []
+    mocker.patch.multiple(build, UV_LOCK=str(lock), SYNC_MARKER=str(marker))
+    mocker.patch.object(build.shutil, "which", return_value="/usr/bin/uv" if uv_found else None)
+    mocker.patch.object(build.os.path, "exists", return_value=uv_found)
+    mocker.patch.object(build.subprocess, "run", side_effect=lambda cmd, **kw: calls.append(cmd))
+
+    build.sync_python_env()
+    return marker, calls
+
+  def test_first_run_syncs_and_records_marker(self, mocker, tmp_path):
+    marker, calls = self._run(mocker, tmp_path)
+    assert len(calls) == 1
+    assert "sync" in calls[0] and "--frozen" in calls[0]
+    assert marker.read_text().strip() == DIGEST_V1
+
+  def test_unchanged_lock_is_noop(self, mocker, tmp_path):
+    _, calls = self._run(mocker, tmp_path, marker_text=DIGEST_V1)
+    assert calls == []
+
+  def test_changed_lock_triggers_resync(self, mocker, tmp_path):
+    marker, calls = self._run(mocker, tmp_path, marker_text=hashlib.sha256(b"OLD").hexdigest())
+    assert len(calls) == 1
+    assert marker.read_text().strip() == DIGEST_V1
+
+  def test_missing_lockfile_is_noop(self, mocker, tmp_path):
+    _, calls = self._run(mocker, tmp_path, lock_bytes=None)
+    assert calls == []
+
+  def test_missing_uv_binary_is_noop(self, mocker, tmp_path):
+    _, calls = self._run(mocker, tmp_path, uv_found=False)
+    assert calls == []


### PR DESCRIPTION
## Problem

Some devices upgrading from an older BluePilot version into bp-7.0 hit a build failure on boot:

```
openpilot failed to build
ModuleNotFoundError: No module named 'acados'
  File "/data/openpilot/SConstruct", line 44
    pkgs = [importlib.import_module(name) for name in pkg_names]
```

It's intermittent because it depends on the upgrade path, not the version itself.

## Root cause

The device's `.venv` is provisioned once at install time (`uv sync`) and then persists across updates. But nothing reconciles it with the updated lockfile afterwards — `updated.py`'s `fetch_update()` only does `git fetch` / `reset --hard` / `clean` / submodule update. The launch scripts don't re-sync either.

bp-7.0 changed `acados` from a repo-vendored package (`third_party/acados`, which `SConstruct` explicitly skipped importing on-device) into a `uv`-managed dependency that `SConstruct` now imports unconditionally on every arch. So a device whose venv predates that change updates the git tree, but its venv never gains `acados`, and scons dies importing it at `SConstruct:44`.

- Fresh installs / re-flashes run `uv sync` → work.
- In-place OTA updates carry a stale venv forward → `ModuleNotFoundError`.

## Fix

`build.py` is the single choke point for every source build (OTA, local `git pull`, branch switch, first install), so reconcile there. Before scons, run `uv sync --frozen --inexact`, gated on a sha256 of `uv.lock` recorded inside the venv:

- **Offline-safe:** normal boots are a no-op (the recorded digest matches); the sync only runs on the first boot after the lockfile actually changes, which follows an update the device just downloaded over the network.
- **`--frozen`:** installs exactly what `uv.lock` pins, no re-resolution.
- **`--inexact`:** only adds missing packages, never removes a developer's extras.
- **Fail-loud:** if the sync fails (e.g. no connectivity), show a clear remediation window instead of a raw import traceback; it self-heals on the next connected boot.

The marker lives inside `.venv`, so a wiped/recreated venv naturally re-syncs.

## Testing

- Added `system/manager/test/test_build.py` covering the gate: first-run syncs + records the marker, unchanged lock is a no-op, changed lock re-syncs, and missing `uv.lock` / missing `uv` binary are safe no-ops.
- Verified end-to-end against a real in-sync venv: first call runs the actual `uv sync` (71 packages, no changes), second call is a ~3ms no-op.