### PR TITLE
ford: show "Radar Not Detected" when the radar bus is silent

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -134,6 +134,7 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     audioFeedback @97;
 
     soundsUnavailableDEPRECATED @47;
+    radarIsNotDetected @100;
   }
 }
 

--- a/opendbc_repo/opendbc/car/car.capnp
+++ b/opendbc_repo/opendbc/car/car.capnp
@@ -305,6 +305,7 @@ struct RadarData @0x888ad6581cf0aacb {
     radarFault @1 :Bool;
     wrongConfig @2 :Bool;
     radarUnavailableTemporary @3 :Bool;  # radar data is temporarily unavailable due to conditions the car sets
+    radarUnavailablePermanent @4 :Bool;  # radar data is permanently unavailable due to not having ACC
   }
 
   # similar to LiveTracks

--- a/opendbc_repo/opendbc/car/ford/radar_interface.py
+++ b/opendbc_repo/opendbc/car/ford/radar_interface.py
@@ -25,6 +25,7 @@ DELPHI_MRR_MIN_LONG_RANGE_DIST = 30  # meters
 DELPHI_MRR_CLUSTER_THRESHOLD = 5  # meters, lateral distance and relative velocity are weighted
 
 STEER_ASSIST_DATA_MSGS = 0x3d7
+RADAR_ABSENT_ = 500 #Used to detect if the radar is absent for 5s and then set the radarUnavailablePermanent flag to True
 
 @dataclass
 class Cluster:
@@ -123,6 +124,8 @@ class RadarInterface(RadarInterfaceBase):
     self.radar = DBC[CP.carFingerprint].get(Bus.radar)
     self.scan_index_invalid_cnt = 0
     self.radar_unavailable_cnt = 0
+    self.radar_perm_cnt = 0
+    self.radar_working = False
     self.prev_headerScanIndex = 0
     if CP.radarUnavailable:
       self.rcp = None
@@ -151,8 +154,16 @@ class RadarInterface(RadarInterfaceBase):
     self.updated_messages.update(vls)
 
     if self.trigger_msg not in self.updated_messages:
+      if not self.radar_working:
+        self.radar_perm_cnt += 1
+        if self.radar_perm_cnt >= RADAR_ABSENT_:
+          ret = structs.RadarData()
+          ret.errors.radarUnavailablePermanent = True
+          return ret
       return None
     self.updated_messages.clear()
+    self.radar_working = True
+    self.radar_perm_cnt = 0
 
     ret = structs.RadarData()
     if not self.rcp.can_valid:

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -706,6 +706,11 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.NO_ENTRY: NoEntryAlert("Radar Temporarily Unavailable"),
   },
 
+  EventName.radarIsNotDetected: {
+    ET.PERMANENT: NormalPermanentAlert("Car may not have ACC"),
+    ET.NO_ENTRY: NoEntryAlert("Radar Is Not Detected"),
+  },
+
   # Every frame from the camera should be processed by the model. If modeld
   # is not processing frames fast enough they have to be dropped. This alert is
   # thrown when over 20% of frames are dropped.

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -380,6 +380,8 @@ class SelfdriveD(CruiseHelper):
       self.events.add(EventName.canError)
     elif self.sm['radarState'].radarErrors.radarUnavailableTemporary:
       self.events.add(EventName.radarTempUnavailable)
+    elif self.sm['radarState'].radarErrors.radarUnavailablePermanent:
+      self.events.add(EventName.radarIsNotDetected)
     elif any(self.sm['radarState'].radarErrors.to_dict().values()):
       self.events.add(EventName.radarFault)
     if not self.sm.valid['pandaStates']:


### PR DESCRIPTION
## The evidence that motivated this

- A recurring support pattern: someone installs a comma on a Ford **without ACC/radar hardware**. The car fingerprints fine (its platform's DBC lists a radar bus, so `radarUnavailable` is False), radard spins up expecting radar — and hears nothing.
- Today that surfaces as a generic "Radar Error" or a confusing controls mismatch, and diagnosing "your car just doesn't have the module" costs hours per case.
- The gap is real in code, not just in messaging: `RadarInterface.update()` returns `None` whenever the trigger message hasn't arrived — so a **completely silent** radar bus never reaches the `canError` / `radarUnavailableTemporary` paths at all. Pure absence produced no signal.

## Why the fix is shaped this way

- **Detect where the bus is visible.** The radar CAN only exists inside the radar interface (card process) — carstate never parses it — so the detector lives in `radar_interface.py`, keyed on the trigger message.
- **A grace window, counted in frames**: 500 update calls at card's 100 Hz ≈ 5 s of continuous silence before declaring absence — frame-counted (not wall-clock) so replay is deterministic, and long enough that a slow-waking radar never false-trips.
- **A one-way "ever heard it" latch** (`radar_working`): a radar that worked and then dropped out can never trip this flag — that stays `radarUnavailableTemporary`'s job. Permanent means *never seen since startup*.
- **Free gating for cars that legitimately lack radar**: this code is unreachable when `radarUnavailable` is set (the constructor leaves `rcp = None`), so alpha-long cars can't false-positive.
- **Reuse the whole alert pipeline**: one new `RadarData.Error` flag (`radarUnavailablePermanent @4`, sibling of `radarUnavailableTemporary`), one new `EventName.radarIsNotDetected` in the live `log.capnp` enum, one `elif` in selfdrived ahead of the generic radarFault catch-all, one alert entry ("Car may not have ACC"). No new process, no new UI surface.

## The evidence afterwards

- A real Ford `RadarInterface` driven with a fully silent bus raises `radarUnavailablePermanent` at exactly frame 500 and stays quiet before the grace elapses; a radar that speaks first (even once, even late) never trips it.
- Schema checks: the new field and event resolve through capnp against the enums the code actually reads (`log.OnroadEvent.EventName`, not the deprecated car.capnp copy).

## What each change is

- `opendbc/car/ford/radar_interface.py`: the detector — `RADAR_ABSENT_` grace counter + `radar_working` latch in the silent branch of `update()`.
- `opendbc/car/car.capnp`: `radarUnavailablePermanent @4` in `RadarData.Error`.
- `cereal/log.capnp`: `radarIsNotDetected @100` in the live `OnroadEvent.EventName` enum.
- `selfdrive/selfdrived/selfdrived.py`: map the flag to the event, ahead of the generic catch-all.
- `selfdrive/selfdrived/events.py`: the permanent "Car may not have ACC" alert + no-entry.

## Test it yourself

- Unplug/absent radar (or a bench harness with no radar node): within ~5 s of onroad the permanent banner reads the real cause instead of "Radar Error".
- Normal car: drive as usual — the flag requires *zero* radar messages since startup, so any functioning radar (even a briefly glitchy one) never shows it.

## Risks / limits

- Ford-scoped detector; other brands keep today's behavior.
- Cars that fail to fingerprint at all still show the generic unknown-vehicle path — that's a separate (fingerprinting) problem this PR deliberately doesn't touch.
- The alert blocks engagement (no-entry) exactly as radar faults do today; it adds clarity, not new restriction.
