### PR TITLE
anti-stall in turns

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -112,6 +112,8 @@ _STALL_MAX_BLIPS = 3         # give up on a stuck episode; devLim telemetry keep
 # the PSCM while the car is straight and the command is small -- a 300 ms lateral gap right at
 # hand-off, imperceptible, instead of a missed curve. The reactive detector above stays as backstop.
 _PRESS_BLIP_MIN_S = 0.5      # press must last this long before its release earns a pulse
+# The pulse releases steering for 300 ms; never fire it in a curve.
+_BLIP_MAX_PATH_ANGLE = 0.10  # rad
 
 
 def pscm_d_ref_m(v_ego_ms: float) -> float:
@@ -307,7 +309,8 @@ class LateralAngleExt:
       self.press_timer_s += _STEER_DT
     else:
       if (self.press_timer_s >= _PRESS_BLIP_MIN_S and self.stall_blip_cooldown_s <= 0.0
-          and self.stall_blip_frames_left <= 0):
+          and self.stall_blip_frames_left <= 0
+          and abs(self.path_angle_last) < _BLIP_MAX_PATH_ANGLE):
         self.stall_blip_frames_left = _STALL_BLIP_FRAMES
       self.press_timer_s = 0.0
 
@@ -544,7 +547,8 @@ class LateralAngleExt:
     if _stalled:
       if self.bp_curvature_deviation_limited and self.stall_blip_cooldown_s <= 0.0:
         self.stall_blip_hold_s += _STEER_DT
-      if self.stall_blip_hold_s >= _STALL_HOLD_S and self.stall_blip_count < _STALL_MAX_BLIPS:
+      if (self.stall_blip_hold_s >= _STALL_HOLD_S and self.stall_blip_count < _STALL_MAX_BLIPS
+          and abs(self.path_angle_last) < _BLIP_MAX_PATH_ANGLE):
         self.stall_blip_frames_left = _STALL_BLIP_FRAMES
         self.stall_blip_hold_s = 0.0
         self.stall_blip_count += 1


### PR DESCRIPTION
Don't engage anti-stall in a curve, since this was unwinding rather than holding.
