### PR TITLE
Recognize 2024-25 F-150 Lightning VINs in the fingerprint fallback

### DIFF
--- a/opendbc_repo/opendbc/car/ford/values.py
+++ b/opendbc_repo/opendbc/car/ford/values.py
@@ -139,8 +139,15 @@ MY_2020, MY_2021, MY_2022, MY_2023, MY_2024, MY_2025 = 'L', 'M', 'N', 'P', 'R', 
 
 # VIN tables sourced from https://github.com/commaai/openpilot/issues/31052 and NHTSA vPIC
 # F-150 and Lightning share WMI and body codes; position 8 is the powertrain, L/V = electric
-F150_VDS_CODES = {'F1C', 'F1E', 'W1C', 'W1E', 'X1C', 'X1E', 'W1R', 'W1P', 'W1S', 'W1T'}
-F150_ELECTRIC_CODES = {'L', 'V'}
+#
+# W1B/W3L/W5L/W7L are the 2024-25 series codes (Pro / XLT+Flash / Lariat / Platinum), and K/S/7/M
+# are the matching 2024-25 SR/ER powertrain codes. Without these a real 2024-25 Lightning VIN (for
+# example 1FT6W3L78SWG05094) fails the vds_codes check before position 8 is even read, and falls
+# through to no match. This set is the best known mapping, not yet cross-checked against the Ford
+# Pro VIN guide.
+F150_VDS_CODES = {'F1C', 'F1E', 'W1C', 'W1E', 'X1C', 'X1E', 'W1R', 'W1P', 'W1S', 'W1T',
+                   'W1B', 'W3L', 'W5L', 'W7L'}
+F150_ELECTRIC_CODES = {'L', 'V', 'K', 'S', '7', 'M'}
 MACH_E_VDS_CODES = {'K1R', 'K1S', 'K2S', 'K3R', 'K3S', 'K4S'}
 
 

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_vin_fingerprint.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_vin_fingerprint.py
@@ -21,6 +21,18 @@ CASES = [
   ('1FTVW1EL4NWXXXXXX', CAR.FORD_F_150_LIGHTNING_MK1),  # position 8 = L -> electric
   ('1FTFW1E85MFXXXXXX', CAR.FORD_F_150_MK14),           # same body code, position 8 = E -> ICE
 
+  # 2024-25 generation: body code 6, per-trim series codes W1B/W3L/W5L/W7L, SR/ER powertrain
+  # codes K/S/7/M. This set is the best known mapping, not yet cross-checked against the Ford
+  # Pro VIN guide.
+  ('1FT6W3L78SWG05094', CAR.FORD_F_150_LIGHTNING_MK1),  # real VIN, 2025 Lightning Flash, ER
+  ('1FT6W1BK8RGXXXXXX', CAR.FORD_F_150_LIGHTNING_MK1),  # 2024 Lightning Pro, SR
+  ('1FT6W7LM8SGXXXXXX', CAR.FORD_F_150_LIGHTNING_MK1),  # 2025 Lightning Platinum, ER fleet
+
+  ('1FT6W3LC8SWXXXXXX', None),                          # 2025 gas F-150, same series, non-electric position 8
+  ('1FTBW3XKXPKB78450', None),                          # real 2023 E-Transit, series W3X, shares the old BEV code K
+  ('1FT6W3XK8SWXXXXXX', None),                          # E-Transit-shaped 2024-25 VIN, series W3X, new BEV code K
+  ('1FT6F4H78SWXXXXXX', None),                          # illustrative non-F-150 series (not a verified real code)
+
   # Constructed from NHTSA vPIC decodes (real VIN prefixes, filler serials) for the platforms
   # that have no VIN in comma's segment database
   ('2FMPK4J97NBXXXXXX', CAR.FORD_EDGE_MK2),             # Edge 2022


### PR DESCRIPTION
## Problem

`match_vin_to_car` (opendbc/car/ford/values.py) is the last-resort fallback used when firmware
fuzzy matching finds nothing. It gates on three things in order: WMI, a `vds_codes` check against
VIN positions 4-7, and model year, then uses position 8 to tell an F-150 apart from a Lightning.

`F150_VDS_CODES` only contains the 2022-23 series codes. A 2024-25 Lightning uses a different body
code and different per-trim series codes, so it fails the `vds_codes` check before position 8 is
ever read, and `match_vin_to_car` returns no match. A real 2025 Lightning VIN
(`1FT6W3L78SWG05094`) currently falls straight through to no match.

## Fix

Add the 2024-25 series codes to `F150_VDS_CODES`: `W1B` (Pro), `W3L` (XLT and Flash), `W5L`
(Lariat), `W7L` (Platinum). Add the matching 2024-25 SR/ER powertrain codes to
`F150_ELECTRIC_CODES`: `K`, `S` (SR), `7`, `M` (ER). `FORD_F_150_LIGHTNING_MK1.years` already
includes 2024 and 2025, so no change was needed there.

`F150_VDS_CODES` is shared between `FORD_F_150_MK14` and `FORD_F_150_LIGHTNING_MK1`, so the new
series codes must not let a gas F-150 or an E-Transit sharing the same WMI get pulled in. Position
8 is what tells the Lightning apart from a gas F-150 once the series code matches, and it already
did before this change; this only adds the 2024-25 codes to the same check.

## Testing

Added cases to `opendbc/sunnypilot/car/ford/tests/test_vin_fingerprint.py`:

- The real 2025 Lightning VIN, plus a 2024 Lightning Pro (SR) and a 2025 Lightning Platinum fleet
  (ER) VIN, all resolving to `FORD_F_150_LIGHTNING_MK1`.
- A 2025 gas F-150 with the same series code and a non-electric position 8, which must stay
  unmatched.
- The real E-Transit VIN, which must stay unmatched.
- An E-Transit-shaped 2024-25 VIN using one of the new powertrain codes, which must stay unmatched
  even with the new codes added, since its series code (`W3X`) is not one of the F-150 codes.
- An illustrative non-F-150 series code, to check the gate rejects codes outside the known set.

All 30 cases pass, including the two pre-existing 2022-23 cases (no regression).

## Note

The 2024-25 series and powertrain codes are the best known mapping and have not been
cross-checked against the Ford Pro VIN guide. The existing 2022-23 code set carries the same
caveat.
