### PR TITLE
ford ALP: cap the applied lane-centering correction at 0.0015

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
@@ -44,8 +44,10 @@ from numpy import interp
 # Laneline confidence blend -- ported verbatim from lateral_curv_ext.py's path_offset blend
 # (laneline_width_tolerance / min_laneline_confidence_bp) so both control schemes agree on what
 # "good lane lines" means.
-_WIDTH_TOLERANCE_BP = (3.75, 4.25)  # m
-_WIDTH_TOLERANCE_V = (0.81, 0.59)
+_WIDTH_TOLERANCE_BP = (2.4, 2.8, 3.75, 4.25)  # m - the floor is added from StarPilot
+_WIDTH_TOLERANCE_V = (0.0, 0.81, 0.81, 0.59) # Adds StarPilot's low edge
+_STD_TOLERANCE_BP = (0.3, 0.5) #0.3 is from StarPilot to define bad references
+_STD_TOLERANCE_V = (0.81, 0.0) #0.81 is a known good value and allows it to fade to zero as std increases
 _CONFIDENCE_BP = (0.6, 0.8)
 _CONFIDENCE_V = (0.0, 1.0)
 
@@ -61,6 +63,8 @@ _LOOKAHEAD_MAX_M = 35.0
 # Hard safety ceiling on the raw correction magnitude (1/m) -- fixed, not a "feel" knob, same
 # treatment as _PSCM_SAT_UNWIND_RATE / _soft_roc in lateral_angle_ext.py.
 _MAX_RAW_CORRECTION = 0.004
+
+_MAX_APPLIED_CORRECTION = 0.0015 #Stops a fake stuck steering rack from happening, because it is under the curvature error and stall gap
 
 # First-order smoothing time constant (s) -- avoids abrupt jumps in the trim.
 _SMOOTH_TAU_S = 0.4
@@ -91,6 +95,9 @@ class LaneCenterTrim:
     if speed_factor <= 0.0:
       self.reset()
       return kappa_cmd
+    if not (np.isfinite(offset) and np.isfinite(gain)): #stops not a number from getting to steering command; validation of number
+      self.reset()
+      return kappa_cmd
 
     valid, raw = self._raw_correction(model, v_ego, offset)
     if not valid:
@@ -101,6 +108,7 @@ class LaneCenterTrim:
       return kappa_cmd
 
     target = float(np.clip(raw, -_MAX_RAW_CORRECTION, _MAX_RAW_CORRECTION)) * float(np.clip(gain, 0.0, 1.0)) * speed_factor
+    target = float(np.clip(target, -_MAX_APPLIED_CORRECTION, _MAX_APPLIED_CORRECTION))
     alpha = 1.0 - np.exp(-0.05 / _SMOOTH_TAU_S)  # BluePilot lateral tick is 20 Hz (dt=0.05s)
     self._correction = float(alpha * target + (1.0 - alpha) * self._correction)
     return kappa_cmd + self._correction
@@ -141,7 +149,8 @@ class LaneCenterTrim:
     try:
       lane_lines = model.laneLines
       probs = model.laneLineProbs
-      if len(lane_lines) < 3 or len(probs) < 3:
+      stds = model.laneLineStds # a line could exist but this verifies how sure it is of where it is
+      if len(lane_lines) < 3 or len(probs) < 3 or len(stds) < 3:
         return 0.0, 0.0
 
       left_x = np.asarray(lane_lines[1].x, dtype=float)
@@ -166,7 +175,8 @@ class LaneCenterTrim:
       # probability via min() -- a single missing/unreliable line (e.g. no line on the curb
       # side, only a center stripe) drags confidence toward 0 on its own.
       width_tolerance = float(np.interp(width, _WIDTH_TOLERANCE_BP, _WIDTH_TOLERANCE_V))
-      confidence = min(float(probs[1]), float(probs[2]), width_tolerance)
+      std_tolerance = float(np.interp(max(float(stds[1]), float(stds[2])), _STD_TOLERANCE_BP, _STD_TOLERANCE_V)) #StarPilot stopped at 0.3, this fades the std through the table
+      confidence = min(float(probs[1]), float(probs[2]), width_tolerance, std_tolerance) #confidence is the weakest signal
       scale = float(np.clip(np.interp(confidence, _CONFIDENCE_BP, _CONFIDENCE_V), 0.0, 1.0))
       center_y = 0.5 * (left + right)
       return scale, center_y

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
@@ -64,8 +64,6 @@ _LOOKAHEAD_MAX_M = 35.0
 # treatment as _PSCM_SAT_UNWIND_RATE / _soft_roc in lateral_angle_ext.py.
 _MAX_RAW_CORRECTION = 0.004
 
-_MAX_APPLIED_CORRECTION = 0.0015 #Stops a fake stuck steering rack from happening, because it is under the curvature error and stall gap
-
 # First-order smoothing time constant (s) -- avoids abrupt jumps in the trim.
 _SMOOTH_TAU_S = 0.4
 
@@ -108,7 +106,6 @@ class LaneCenterTrim:
       return kappa_cmd
 
     target = float(np.clip(raw, -_MAX_RAW_CORRECTION, _MAX_RAW_CORRECTION)) * float(np.clip(gain, 0.0, 1.0)) * speed_factor
-    target = float(np.clip(target, -_MAX_APPLIED_CORRECTION, _MAX_APPLIED_CORRECTION))
     alpha = 1.0 - np.exp(-0.05 / _SMOOTH_TAU_S)  # BluePilot lateral tick is 20 Hz (dt=0.05s)
     self._correction = float(alpha * target + (1.0 - alpha) * self._correction)
     return kappa_cmd + self._correction

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lane_center_trim.py
@@ -64,6 +64,8 @@ _LOOKAHEAD_MAX_M = 35.0
 # treatment as _PSCM_SAT_UNWIND_RATE / _soft_roc in lateral_angle_ext.py.
 _MAX_RAW_CORRECTION = 0.004
 
+_MAX_APPLIED_CORRECTION = 0.0015 #Stops a fake stuck steering rack from happening, because it is under the curvature error and stall gap
+
 # First-order smoothing time constant (s) -- avoids abrupt jumps in the trim.
 _SMOOTH_TAU_S = 0.4
 
@@ -106,6 +108,7 @@ class LaneCenterTrim:
       return kappa_cmd
 
     target = float(np.clip(raw, -_MAX_RAW_CORRECTION, _MAX_RAW_CORRECTION)) * float(np.clip(gain, 0.0, 1.0)) * speed_factor
+    target = float(np.clip(target, -_MAX_APPLIED_CORRECTION, _MAX_APPLIED_CORRECTION))
     alpha = 1.0 - np.exp(-0.05 / _SMOOTH_TAU_S)  # BluePilot lateral tick is 20 Hz (dt=0.05s)
     self._correction = float(alpha * target + (1.0 - alpha) * self._correction)
     return kappa_cmd + self._correction

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
@@ -107,7 +107,7 @@ class TestLaneCenterTrim(unittest.TestCase):
     # speed authority means the filtered correction converges to that ceiling.
     model = _good_model()
     self._run(model, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
 
   def test_gain_scales_correction_linearly(self):
     model = _good_model()
@@ -117,7 +117,7 @@ class TestLaneCenterTrim(unittest.TestCase):
   def test_negative_offset_flips_sign(self):
     model = _good_model()
     self._run(model, offset=-5.0, gain=0.5, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, -0.0015, places=4)
+    self.assertAlmostEqual(self.trim.correction, -0.002, places=4)
 
   def test_speed_ramp_zero_below_9ms(self):
     model = _good_model()
@@ -133,7 +133,7 @@ class TestLaneCenterTrim(unittest.TestCase):
   def test_added_to_kappa_cmd(self):
     model = _good_model()
     result = self._run(model, kappa_cmd=0.01, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(result, 0.01 + 0.0015, places=4)
+    self.assertAlmostEqual(result, 0.01 + 0.004, places=4)
 
   def test_reset_zeroes_filter(self):
     model = _good_model()
@@ -157,14 +157,14 @@ class TestLaneCenterTrim(unittest.TestCase):
     # the model's own path, exactly as if lane lines were centered and confident.
     no_lines = _no_lanelines_model()
     self._run(no_lines, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)  # same ceiling as good lanelines
+    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)  # same ceiling as good lanelines
 
   def test_one_sided_laneline_still_applies_offset(self):
     # Only one ego line confidently detected -- min(probL, probR, width_tol) is dragged down by
     # the missing side, same as fully-missing lines.
     one_sided = _one_sided_model()
     self._run(one_sided, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
 
   def test_no_lanelines_zero_offset_no_correction(self):
     # No lanelines AND no user bias: target collapses to the model's own path, so there's truly
@@ -193,7 +193,7 @@ class TestLaneCenterTrim(unittest.TestCase):
     # smoothly (not a crash / hard reject) and the offset-only fallback still applies.
     weird_width = _good_model(width=15.0)
     self._run(weird_width, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
 
   def test_no_model_position_hard_resets(self):
     # Unlike laneline-only failures, a missing/invalid model.position leaves no baseline to

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
@@ -203,6 +203,47 @@ class TestLaneCenterTrim(unittest.TestCase):
     self._run(broken, offset=5.0, gain=1.0, iterations=50)
     self.assertEqual(self.trim.correction, 0.0)
 
+  # --- Hardening: guards restored from the reference implementation ---
+
+  def test_narrow_lane_not_centered(self):
+    # Two confident stripes 1.5 m apart (double-stripe repaint, gore-point paint) must NOT be
+    # treated as a lane to center in: the width-tolerance low edge zeroes the laneline scale,
+    # so with no user bias there is no correction at all.
+    narrow = _good_model(lane_center_y=1.0, model_y=0.0, width=1.5)
+    self._run(narrow, offset=0.0, gain=1.0, iterations=500)
+    self.assertAlmostEqual(self.trim.correction, 0.0, places=6)
+
+  def test_high_std_ignores_laneline_center(self):
+    # High positional uncertainty (rain/glare: the model is sure lines exist but not where)
+    # must drag centering authority to zero even when probabilities are high.
+    blurry = _good_model(lane_center_y=2.0, model_y=0.0, stds=(0.1, 0.6, 0.1, 0.1))
+    self._run(blurry, offset=0.0, gain=1.0, iterations=500)
+    self.assertAlmostEqual(self.trim.correction, 0.0, places=6)
+
+  def test_nan_offset_is_inert(self):
+    # A corrupt float param must never reach the wire: NaN offset -> no correction, kappa_cmd
+    # passes through untouched.
+    result = self._run(_good_model(), kappa_cmd=0.01, offset=float("nan"), iterations=10)
+    self.assertEqual(self.trim.correction, 0.0)
+    self.assertEqual(result, 0.01)
+
+  def test_nan_gain_is_inert(self):
+    result = self._run(_good_model(), kappa_cmd=0.01, offset=0.3, gain=float("nan"), iterations=10)
+    self.assertEqual(self.trim.correction, 0.0)
+    self.assertEqual(result, 0.01)
+
+  def test_fallback_bias_is_position_independent_by_design(self):
+    # Pins the fallback semantics deliberately: with no lanelines, error == offset regardless of
+    # where the model path is (target moves with the baseline), i.e. the bias is a constant push,
+    # not a position controller. If this ever changes, it should change on purpose.
+    a = _no_lanelines_model(model_y=0.0)
+    b = _no_lanelines_model(model_y=-3.0)
+    self._run(a, offset=0.3, gain=1.0, iterations=500)
+    correction_a = self.trim.correction
+    self.trim.reset()
+    self._run(b, offset=0.3, gain=1.0, iterations=500)
+    self.assertAlmostEqual(self.trim.correction, correction_a, places=9)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
@@ -28,13 +28,14 @@ class _Position:
 
 
 class _Model:
-  def __init__(self, lane_lines, probs, pos_x, pos_y):
+  def __init__(self, lane_lines, probs, stds, pos_x, pos_y):
     self.laneLines = lane_lines
     self.laneLineProbs = probs
+    self.laneLineStds = stds # add stds
     self.position = _Position(pos_x, pos_y)
 
 
-def _good_model(lane_center_y=0.0, model_y=0.0, width=3.7, probs=(0.9, 0.9, 0.9, 0.9)):
+def _good_model(lane_center_y=0.0, model_y=0.0, width=3.7, probs=(0.9, 0.9, 0.9, 0.9), stds=(0.1, 0.1, 0.1, 0.1)):
   """Confident lane lines (probability + typical width) centered at lane_center_y."""
   xs = list(range(0, 60, 2))
   half = width / 2.0
@@ -46,7 +47,7 @@ def _good_model(lane_center_y=0.0, model_y=0.0, width=3.7, probs=(0.9, 0.9, 0.9,
   ]
   pos_x = list(range(0, 60, 2))
   pos_y = [model_y] * len(pos_x)
-  return _Model(lane_lines, list(probs), pos_x, pos_y)
+  return _Model(lane_lines, list(probs), list(stds), pos_x, pos_y)
 
 
 def _no_lanelines_model(model_y=0.0):
@@ -106,17 +107,17 @@ class TestLaneCenterTrim(unittest.TestCase):
     # speed authority means the filtered correction converges to that ceiling.
     model = _good_model()
     self._run(model, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=3)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_gain_scales_correction_linearly(self):
     model = _good_model()
-    self._run(model, offset=5.0, gain=0.5, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.002, places=3)
+    self._run(model, offset=5.0, gain=0.25, iterations=500)
+    self.assertAlmostEqual(self.trim.correction, 0.001, places=4)
 
   def test_negative_offset_flips_sign(self):
     model = _good_model()
-    self._run(model, offset=-5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, -0.004, places=3)
+    self._run(model, offset=-5.0, gain=0.5, iterations=500)
+    self.assertAlmostEqual(self.trim.correction, -0.0015, places=4)
 
   def test_speed_ramp_zero_below_9ms(self):
     model = _good_model()
@@ -125,14 +126,14 @@ class TestLaneCenterTrim(unittest.TestCase):
 
   def test_speed_ramp_partial_between_9_and_15ms(self):
     model = _good_model()
-    self._run(model, offset=5.0, gain=1.0, v_ego=12.0, iterations=500)
+    self._run(model, offset=5.0, gain=0.5, v_ego=12.0, iterations=500)
     # speed_factor at 12 m/s is 0.5 on the [9, 15] -> [0, 1] ramp
-    self.assertAlmostEqual(self.trim.correction, 0.004 * 0.5, places=3)
+    self.assertAlmostEqual(self.trim.correction, 0.001, places=4)
 
   def test_added_to_kappa_cmd(self):
     model = _good_model()
     result = self._run(model, kappa_cmd=0.01, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(result, 0.01 + 0.004, places=3)
+    self.assertAlmostEqual(result, 0.01 + 0.0015, places=4)
 
   def test_reset_zeroes_filter(self):
     model = _good_model()
@@ -156,14 +157,14 @@ class TestLaneCenterTrim(unittest.TestCase):
     # the model's own path, exactly as if lane lines were centered and confident.
     no_lines = _no_lanelines_model()
     self._run(no_lines, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=3)  # same ceiling as good lanelines
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)  # same ceiling as good lanelines
 
   def test_one_sided_laneline_still_applies_offset(self):
     # Only one ego line confidently detected -- min(probL, probR, width_tol) is dragged down by
     # the missing side, same as fully-missing lines.
     one_sided = _one_sided_model()
     self._run(one_sided, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=3)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_no_lanelines_zero_offset_no_correction(self):
     # No lanelines AND no user bias: target collapses to the model's own path, so there's truly
@@ -192,13 +193,13 @@ class TestLaneCenterTrim(unittest.TestCase):
     # smoothly (not a crash / hard reject) and the offset-only fallback still applies.
     weird_width = _good_model(width=15.0)
     self._run(weird_width, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=3)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_no_model_position_hard_resets(self):
     # Unlike laneline-only failures, a missing/invalid model.position leaves no baseline to
     # offset from at all -- this is the one case that still hard-resets to zero.
     broken = _Model(lane_lines=[_XY([], []), _XY([], []), _XY([], []), _XY([], [])],
-                     probs=[0.9, 0.9, 0.9, 0.9], pos_x=[], pos_y=[])
+                     probs=[0.9, 0.9, 0.9, 0.9],stds=[0.1, 0.1, 0.1, 0.1], pos_x=[], pos_y=[])
     self._run(broken, offset=5.0, gain=1.0, iterations=50)
     self.assertEqual(self.trim.correction, 0.0)
 

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_lane_center_trim.py
@@ -107,7 +107,7 @@ class TestLaneCenterTrim(unittest.TestCase):
     # speed authority means the filtered correction converges to that ceiling.
     model = _good_model()
     self._run(model, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_gain_scales_correction_linearly(self):
     model = _good_model()
@@ -117,7 +117,7 @@ class TestLaneCenterTrim(unittest.TestCase):
   def test_negative_offset_flips_sign(self):
     model = _good_model()
     self._run(model, offset=-5.0, gain=0.5, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, -0.002, places=4)
+    self.assertAlmostEqual(self.trim.correction, -0.0015, places=4)
 
   def test_speed_ramp_zero_below_9ms(self):
     model = _good_model()
@@ -133,7 +133,7 @@ class TestLaneCenterTrim(unittest.TestCase):
   def test_added_to_kappa_cmd(self):
     model = _good_model()
     result = self._run(model, kappa_cmd=0.01, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(result, 0.01 + 0.004, places=4)
+    self.assertAlmostEqual(result, 0.01 + 0.0015, places=4)
 
   def test_reset_zeroes_filter(self):
     model = _good_model()
@@ -157,14 +157,14 @@ class TestLaneCenterTrim(unittest.TestCase):
     # the model's own path, exactly as if lane lines were centered and confident.
     no_lines = _no_lanelines_model()
     self._run(no_lines, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)  # same ceiling as good lanelines
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)  # same ceiling as good lanelines
 
   def test_one_sided_laneline_still_applies_offset(self):
     # Only one ego line confidently detected -- min(probL, probR, width_tol) is dragged down by
     # the missing side, same as fully-missing lines.
     one_sided = _one_sided_model()
     self._run(one_sided, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_no_lanelines_zero_offset_no_correction(self):
     # No lanelines AND no user bias: target collapses to the model's own path, so there's truly
@@ -193,7 +193,7 @@ class TestLaneCenterTrim(unittest.TestCase):
     # smoothly (not a crash / hard reject) and the offset-only fallback still applies.
     weird_width = _good_model(width=15.0)
     self._run(weird_width, offset=5.0, gain=1.0, iterations=500)
-    self.assertAlmostEqual(self.trim.correction, 0.004, places=4)
+    self.assertAlmostEqual(self.trim.correction, 0.0015, places=4)
 
   def test_no_model_position_hard_resets(self):
     # Unlike laneline-only failures, a missing/invalid model.position leaves no baseline to


### PR DESCRIPTION
**Description**

Split out from #179 per review. Adds a post-gain ceiling of 0.0015 on the applied lane-centering correction, strictly inside the deviation clip's budget (CURVATURE_ERROR = 0.002) and under _STALL_GAP_MIN (0.004) — so the trim alone can never continuously bind the deviation clip (which also discards autocal evidence frames) or feed the stall-blip detector a fake stall. This matters most in the model-position fallback, where the bias error never closes by construction, so a large offset at full gain otherwise sits at the raw 0.004 ceiling permanently on center-stripe-only roads.

Value rationale: above StarPilot's effective ceiling (0.004 raw clip × 0.30 fixed gain = 0.0012), below the 0.002 clip budget. **At the default strength of 0.3 this cap never engages** (0.004 × 0.3 = 0.0012 < 0.0015) — it only bites at gain ≥ ~0.4, so it can't interfere with default-setting testing. The constant is a proposal: raise it freely while tuning (anything ≥ 0.004 makes it a no-op).

Stacked on #179 — merge that first and this diff shrinks to two module lines plus six test assertions.

**Verification**

Unit tests only — not road-tested (car is down). Existing suite updated for the capped ceiling; 25/25 pass.