### PR TITLE
Fix dampening factor clip

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -189,7 +189,7 @@ class LateralAngleExt:
       for attr, key, min_value, max_value in (
         ("low_speed_curv_factor", "FordLowSpeedFactor_ang", 0.5, 1.5),
         ("high_speed_curv_factor", "FordHighSpeedFactor_ang", 0.5, 1.5),
-        ("user_dampening_factor", "FordHighSpeedDampening_ang", 0.75, 1.25),
+        ("user_dampening_factor", "FordHighSpeedDampening_ang", 0.25, 1.25),
       ):
         try:
           raw = params.get(key, return_default=True)


### PR DESCRIPTION
**Description**

UI allows selecting down to 0.25 for user_dampening_factor. If a value below 0.75 is chosen, line 197/198 clips it back up to 0.75. Changed minimum to 0.25 to prevent clipping.


