### PR TITLE
Update dampening factor to .25

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -191,7 +191,7 @@ class LateralAngleExt:
       for attr, key, min_value, max_value in (
         ("low_speed_curv_factor", "FordLowSpeedFactor_ang", 0.5, 1.5),
         ("high_speed_curv_factor", "FordHighSpeedFactor_ang", 0.5, 1.5),
-        ("user_dampening_factor", "FordHighSpeedDampening_ang", 0.75, 1.25),
+        ("user_dampening_factor", "FordHighSpeedDampening_ang", 0.25, 1.25),
       ):
         try:
           raw = params.get(key, return_default=True)


### PR DESCRIPTION
UI allows selecting dampening down to 0.25, but this will get clipped to .75 since that is the min on the param.

