### PR TITLE
Curvature Smoothing

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -466,6 +466,7 @@ class LateralAngleExt:
       self.b_blend = max(target_b_blend, self.b_blend - b_step)
       
     requested_curvature = predicted_curvature * self.b_blend + desired_curvature * (1.0 - self.b_blend)
+    self._desired_curvature_last = desired_curvature
     
     if self.model is not None:
       self.lane_change = self.model.meta.laneChangeState in (1, 2, 3)

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -381,6 +381,7 @@ class LateralAngleExt:
       self.bp_kappa_cmd = self.get_current_curvature(CS)
       self._desired_curvature_last = float(actuators.curvature)
       self.lane_center_trim.reset()
+      self.kappa_gain_filt = 0.0
       self.precision_type = 1
       if self.stall_blip_frames_left <= 0:
         self.stall_blip_cooldown_s = _STALL_COOLDOWN_S

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -156,6 +156,7 @@ class LateralAngleExt:
     self.user_dampening_factor = 1.0
     self.bp_low_speed_curv_factor = 1.0
     self.bp_high_speed_curv_factor = 1.0
+    self.kappa_gain_filt = 0.0     # low pass filtered kappa_cmd used as input of curvature gain interp
     # BluePilot: angle mode's own lane-change scaling factor, independent of curvature mode's
     # lane_change_factor_high_curv -- angle needs a boost (>1) where curvature needs a cut (<1).
     self.lane_change_factor_high_ang = 1.0
@@ -281,6 +282,7 @@ class LateralAngleExt:
       self.human_turn_detector.reset()
       self.angle_human_turn_active = False
       self.lane_center_trim.reset()
+      self.kappa_gain_filt = 0.0
       self.stall_blip_hold_s = 0.0
       self.stall_blip_frames_left = 0
       self.stall_blip_cooldown_s = 0.0
@@ -322,6 +324,7 @@ class LateralAngleExt:
       # Keep exit detection current so resume doesn't compare against a stale pre-turn value.
       self._desired_curvature_last = float(actuators.curvature)
       self.lane_center_trim.reset()
+      self.kappa_gain_filt = 0.0
       # A human turn ends any stall episode -- its own mode 0 does the PSCM reset job. That also
       # covers the press so far: only press time accumulated AFTER the latch releases should earn
       # a hand-off pulse.
@@ -512,8 +515,14 @@ class LateralAngleExt:
     )
     self.high_gain_calc = interp(v_ego, [13.5, 26.82], [(1.30 * self.low_speed_curv_factor), (self.path_angle_gain_highC_highV * self.high_speed_curv_factor)])
 
+    # Low pass filtered kappa is used ONLY in curve factor interp. Reduces noise from road imperfections and other sudden movements
+    self.kappa_gain_filt = (
+      0.85 * self.kappa_gain_filt +
+      0.15 * abs(kappa_cmd)
+    )
+    
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    self.curvature_factor = interp(abs(kappa_cmd), [0.0007, 0.001], [self.low_gain_calc, self.high_gain_calc])
+    self.curvature_factor = interp(self.kappa_gain_filt, [0.0007, 0.001], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor
     path_angle = path_angle_calc

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -522,7 +522,7 @@ class LateralAngleExt:
     )
     
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    self.curvature_factor = interp(self.kappa_gain_filt, [0.0007, 0.001], [self.low_gain_calc, self.high_gain_calc])
+    self.curvature_factor = interp(self.kappa_gain_filt, [0.0005, 0.002], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor
     path_angle = path_angle_calc

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -141,6 +141,7 @@ class LateralAngleExt:
   def __init__(self, CP=None, CP_SP=None):
     # Predicted-curvature blend for path_angle: pred * b + desired * (1-b); b from ``FordPathAngleBlendRatio``
     self.path_angle_blend_ratio = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
+    self.b_blend = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
     # Max extra VLT above t_base; from ``FordVLTExtraMax`` param
     self.vlt_extra_max = _VLT_T_EXTRA_MAX
     # Telemetry: final path_angle (rad) after limits (see bp_card_publisher)
@@ -266,6 +267,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -313,6 +315,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -369,6 +372,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -452,10 +456,16 @@ class LateralAngleExt:
     # Same bug class and fix as _PSCM_SAT_UNWIND_RATE and _soft_roc above.
     _desired_falling = abs(desired_curvature) < abs(self._desired_curvature_last) - 0.010
     _on_exit_near_limit = not _kappa_entering and (_pscm_lim >= 1 or _in_hard_sat or _desired_falling)
-    b_blend = float(clip(b * 0.25, 0.0, 1.0)) if _on_exit_near_limit else b
-    requested_curvature = predicted_curvature * b_blend + desired_curvature * (1.0 - b_blend)
-    self._desired_curvature_last = desired_curvature
-
+    # step function for b_blend. Prevents instant jumps between .5 and .125 predicted_curvature weight
+    target_b_blend = float(clip(b * 0.25, 0.0, 1.0)) if _on_exit_near_limit else b
+    b_step = 0.1
+    if target_b_blend > self.b_blend:
+      self.b_blend = min(target_b_blend, self.b_blend + b_step)
+    else:
+      self.b_blend = max(target_b_blend, self.b_blend - b_step)
+      
+    requested_curvature = predicted_curvature * self.b_blend + desired_curvature * (1.0 - self.b_blend)
+    
     if self.model is not None:
       self.lane_change = self.model.meta.laneChangeState in (1, 2, 3)
     else:


### PR DESCRIPTION
Purpose: Reduce oscillations through curves and coming out of curves. Allows larger gaps between high tuned high speed gain and low tuned dampening factors.

- curvature_gain interp range:
Previous interpolation range was small enough (1600m rad to 1000m rad) that in many situations, the car would go through the whole range at the very start of a curve. Depending on gap between low_gain_calc and high_gain_calc, this could cause a large, fast swing in gain resulting in a noticeable jerk. Further oscillations could occur through curves that fell close to previous interp range as the car attempted to correct.

- kappa_gain_filt:
This, along with the interp range increase, should reduce oscillations that start due to road imperfections or other sudden movements. Effectively sets curve gain based on average of last 300ms of kappa_cmd.

- b_blend steps:
While coming out of curves, _desired_falling can rapidly switch between true/false due to road imperfections. This would cause b_blend value to swap between .125 and .5, causing balance between predicted_curvature and desired_curvature to flap back and forth. Step function prevents b_blend from increasing or decreasing by more than .1 per cycle.

Notes: I tested this over ~1.5 hours of highway driving and it made a fairly large difference for my car, particularly smoothing out curve entrances and lane changes. Did not have the new lane-centering enabled. Not sure how you do road testing nor what the test file folder does, but would be willing to learn/do more.