### PR TITLE
Predicted_Curvature Weight Adjustments

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -141,7 +141,7 @@ class LateralAngleExt:
   def __init__(self, CP=None, CP_SP=None):
     # Predicted-curvature blend for path_angle: pred * b + desired * (1-b); b from ``FordPathAngleBlendRatio``
     self.path_angle_blend_ratio = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
-    self.b_blend = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
+    self.b_blend = self.path_angle_blend_ratio / 2   #initialize halfway between low speed and high speed 
     # Max extra VLT above t_base; from ``FordVLTExtraMax`` param
     self.vlt_extra_max = _VLT_T_EXTRA_MAX
     # Telemetry: final path_angle (rad) after limits (see bp_card_publisher)
@@ -266,7 +266,6 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
-      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -313,7 +312,6 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
-      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -369,7 +367,6 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
-      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -411,10 +408,7 @@ class LateralAngleExt:
     if self.model is not None and len(self.model.orientationRate.z) >= 17:
       _curvatures_ref = np.array(self.model.orientationRate.z) / max(0.01, v_ego)
       _kappa_at_t_base = abs(float(interp(_t_base, ModelConstants.T_IDXS, _curvatures_ref)))
-    _kappa_entering = (
-      abs(desired_curvature) > 0.001 and
-      _kappa_at_t_base > abs(desired_curvature) * 1.25
-    )
+    _kappa_entering = _kappa_at_t_base > abs(desired_curvature) * 1.1
     if _kappa_entering:
       _kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
     else:
@@ -429,8 +423,8 @@ class LateralAngleExt:
         interp(curvature_lookup_time, ModelConstants.T_IDXS, curvatures)
       )
 
-    b = float(self.path_angle_blend_ratio)
-    b = float(clip(b, 0.0, 1.0))
+    b = float(clip(self.path_angle_blend_ratio, 0.0, 1.0))
+    b = interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [b, 0.0])
 
     # Exit-biased blend: near the PSCM authority limit or while the planner is actively
     # reducing curvature (exit detected), drop model prediction weight from 60% → ~15%.
@@ -455,24 +449,17 @@ class LateralAngleExt:
     # 0.04 (1/m)/s, collapsing the model blend on mild straightening instead of genuine exits.
     # Same bug class and fix as _PSCM_SAT_UNWIND_RATE and _soft_roc above.
     _desired_falling = (
-      abs(self._desired_curvature_last) > 0.001 and
-      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.8
+      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.9
     )
     _on_exit_near_limit = not _kappa_entering and (_pscm_lim >= 1 or _in_hard_sat or _desired_falling)
-    _on_straightaway = (not _kappa_entering and not _desired_falling and abs(desired_curvature) < 0.00125)
-    # step function for b_blend. Prevents instant jumps between .5 and .125 predicted_curvature weight
-    if _on_exit_near_limit:
-      target_b_blend = b * 0.25
-    elif _on_straightaway:
-      target_b_blend = b * 0.35
-    else:
-      target_b_blend = b
-    b_step = 0.1
-    if target_b_blend > self.b_blend:
-      self.b_blend = min(target_b_blend, self.b_blend + b_step)
-    else:
-      self.b_blend = max(target_b_blend, self.b_blend - b_step)
-      
+
+    # Low pass filter for b_blend. Prevents instant jumps between .5 and .125 predicted_curvature weight
+    target_b_blend = b * 0.25 if _on_exit_near_limit else b
+    self.b_blend = (
+      0.75 * self.b_blend +
+      0.25 * target_b_blend
+    )
+    
     requested_curvature = predicted_curvature * self.b_blend + desired_curvature * (1.0 - self.b_blend)
     self._desired_curvature_last = desired_curvature
 

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -141,6 +141,7 @@ class LateralAngleExt:
   def __init__(self, CP=None, CP_SP=None):
     # Predicted-curvature blend for path_angle: pred * b + desired * (1-b); b from ``FordPathAngleBlendRatio``
     self.path_angle_blend_ratio = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
+    self.b_blend = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
     # Max extra VLT above t_base; from ``FordVLTExtraMax`` param
     self.vlt_extra_max = _VLT_T_EXTRA_MAX
     # Telemetry: final path_angle (rad) after limits (see bp_card_publisher)
@@ -265,6 +266,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -311,6 +313,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -366,6 +369,7 @@ class LateralAngleExt:
       self.path_angle_last = 0.0
       self.bp_path_angle_final = 0.0
       self.apply_curvature_last = 0.0
+      self.b_blend = self.path_angle_blend_ratio
       self.bp_angle_rate_limited = False
       self.bp_curvature_rate_limited = False
       self.bp_curvature_deviation_limited = False
@@ -407,7 +411,10 @@ class LateralAngleExt:
     if self.model is not None and len(self.model.orientationRate.z) >= 17:
       _curvatures_ref = np.array(self.model.orientationRate.z) / max(0.01, v_ego)
       _kappa_at_t_base = abs(float(interp(_t_base, ModelConstants.T_IDXS, _curvatures_ref)))
-    _kappa_entering = _kappa_at_t_base > abs(desired_curvature)
+    _kappa_entering = (
+      abs(desired_curvature) > 0.001 and
+      _kappa_at_t_base > abs(desired_curvature) * 1.25
+    )
     if _kappa_entering:
       _kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
     else:
@@ -447,10 +454,26 @@ class LateralAngleExt:
     # that same real-world trigger rate on this branch's actual 20Hz cadence; unscaled it fired at
     # 0.04 (1/m)/s, collapsing the model blend on mild straightening instead of genuine exits.
     # Same bug class and fix as _PSCM_SAT_UNWIND_RATE and _soft_roc above.
-    _desired_falling = abs(desired_curvature) < abs(self._desired_curvature_last) - 0.010
+    _desired_falling = (
+      abs(self._desired_curvature_last) > 0.001 and
+      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.8
+    )
     _on_exit_near_limit = not _kappa_entering and (_pscm_lim >= 1 or _in_hard_sat or _desired_falling)
-    b_blend = float(clip(b * 0.25, 0.0, 1.0)) if _on_exit_near_limit else b
-    requested_curvature = predicted_curvature * b_blend + desired_curvature * (1.0 - b_blend)
+    _on_straightaway = (not _kappa_entering and not _desired_falling and abs(desired_curvature) < 0.00125)
+    # step function for b_blend. Prevents instant jumps between .5 and .125 predicted_curvature weight
+    if _on_exit_near_limit:
+      target_b_blend = b * 0.25
+    elif _on_straightaway:
+      target_b_blend = b * 0.35
+    else:
+      target_b_blend = b
+    b_step = 0.1
+    if target_b_blend > self.b_blend:
+      self.b_blend = min(target_b_blend, self.b_blend + b_step)
+    else:
+      self.b_blend = max(target_b_blend, self.b_blend - b_step)
+      
+    requested_curvature = predicted_curvature * self.b_blend + desired_curvature * (1.0 - self.b_blend)
     self._desired_curvature_last = desired_curvature
 
     if self.model is not None:

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -141,7 +141,10 @@ class LateralAngleExt:
   def __init__(self, CP=None, CP_SP=None):
     # Predicted-curvature blend for path_angle: pred * b + desired * (1-b); b from ``FordPathAngleBlendRatio``
     self.path_angle_blend_ratio = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
-    self.b_blend = self.path_angle_blend_ratio / 2   #initialize halfway between low speed and high speed 
+    # Low pass filter values used in calculating kappa
+    self.speed_factor = None  #initialize as None, assign raw value on first cycle then filter
+    self.kappa_factor = None
+    self.b_blend = None
     # Max extra VLT above t_base; from ``FordVLTExtraMax`` param
     self.vlt_extra_max = _VLT_T_EXTRA_MAX
     # Telemetry: final path_angle (rad) after limits (see bp_card_publisher)
@@ -253,7 +256,7 @@ class LateralAngleExt:
     self._ensure_lateral_curv_initialized(CP)
 
     v_ego = float(CS.out.vEgoRaw)
-    d_ref = pscm_d_ref_m(v_ego)
+    d_ref = pscm_d_ref_m(v_ego)   #deprecated
 
     curvature_rate = 0.0
     path_offset = 0.0
@@ -401,18 +404,31 @@ class LateralAngleExt:
     # to command max path_angle through the entire apex. 0.15s gives t_base ≤ 0.20s and VLT ≤ 0.33s, restoring
     # the 2.8m lookahead that kept kappa_entering False at the apex in successful earlier runs.
     _t_base = float(clip(self.sm['liveDelay'].lateralDelay, 0.1, 0.15)) + _DT_MDL
-    _speed_factor = float(interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [1.0, 0.0]))
+    target_speed_factor = float(interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [1.0, 0.0]))
+    #Low Pass Filter for _speed_factor calculation
+    if self.speed_factor is None:
+      self.speed_factor = target_speed_factor
+    else:
+      self.speed_factor = 0.80 * self.speed_factor + 0.20 * target_speed_factor
+    _speed_factor = float(clip(self.speed_factor, 0.0, 1.0))
     # Direction-aware kappa factor: on curve ENTRY (model shows more curvature at t_base than planner now),
     # keep full lookahead so pre-steering begins early. On exit/apex, taper by magnitude to prevent unwind.
     _kappa_at_t_base = 0.0
     if self.model is not None and len(self.model.orientationRate.z) >= 17:
       _curvatures_ref = np.array(self.model.orientationRate.z) / max(0.01, v_ego)
       _kappa_at_t_base = abs(float(interp(_t_base, ModelConstants.T_IDXS, _curvatures_ref)))
-    _kappa_entering = _kappa_at_t_base > abs(desired_curvature) * 1.1
+    _kappa_entering = _kappa_at_t_base > abs(desired_curvature) * 1.05
     if _kappa_entering:
-      _kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
+      target_kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
     else:
-      _kappa_factor = float(interp(abs(desired_curvature), [_VLT_KAPPA_FULL, _VLT_KAPPA_TAPER], [1.0, 0.0]))
+      target_kappa_factor = float(interp(abs(desired_curvature), [_VLT_KAPPA_FULL, _VLT_KAPPA_TAPER], [1.0, 0.0]))
+    #Low Pass Filter for _kappa_factor calculation
+    if self.kappa_factor is None:
+      self.kappa_factor = target_kappa_factor
+    else:
+      self.kappa_factor = 0.80 * self.kappa_factor + 0.20 * target_kappa_factor
+    _kappa_factor = float(clip(self.kappa_factor, 0.0, 1.0))
+    
     curvature_lookup_time = _t_base + self.vlt_extra_max * _speed_factor * _kappa_factor
     self.bp_curvature_lookup_time = curvature_lookup_time
 
@@ -449,18 +465,19 @@ class LateralAngleExt:
     # 0.04 (1/m)/s, collapsing the model blend on mild straightening instead of genuine exits.
     # Same bug class and fix as _PSCM_SAT_UNWIND_RATE and _soft_roc above.
     _desired_falling = (
-      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.9
+      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.95
     )
     _on_exit_near_limit = not _kappa_entering and (_pscm_lim >= 1 or _in_hard_sat or _desired_falling)
 
     # Low pass filter for b_blend. Prevents instant jumps between .5 and .125 predicted_curvature weight
     target_b_blend = b * 0.25 if _on_exit_near_limit else b
-    self.b_blend = (
-      0.75 * self.b_blend +
-      0.25 * target_b_blend
-    )
+    if self.b_blend is None:
+      self.b_blend = target_b_blend
+    else:
+      self.b_blend = 0.80 * self.b_blend + 0.20 * target_b_blend
+    b_blend = float(clip(self.b_blend, 0.0, 1.0))
     
-    requested_curvature = predicted_curvature * self.b_blend + desired_curvature * (1.0 - self.b_blend)
+    requested_curvature = predicted_curvature * b_blend + desired_curvature * (1.0 - b_blend)
     self._desired_curvature_last = desired_curvature
 
     if self.model is not None:
@@ -518,12 +535,17 @@ class LateralAngleExt:
 
     # Speed-interpolated gain: at low speed both curves use 1.0; at high speed the params take effect.
     self.low_gain_calc = interp(
-      v_ego, [13.5, 26.82], [1.0, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
+      v_ego, [11.18, 31.29], [1.00, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
     )
-    self.high_gain_calc = interp(v_ego, [13.5, 26.82], [(1.30 * self.low_speed_curv_factor), (self.path_angle_gain_highC_highV * self.high_speed_curv_factor)])
+    self.high_gain_calc = interp(
+      v_ego, [11.18, 31.29], [(1.40 * self.low_speed_curv_factor), (1.20 * self.path_angle_gain_highC_highV * self.high_speed_curv_factor)]
+    )
+
+    # Speed-interpolated curve-radius: lower the speed, tighter the curves. easing into transition
+    high_gain_boundary = interp(v_ego, [8.94, 13.41, 16.54, 31.29], [0.02, 0.0195, 0.018, 0.0035])
 
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    self.curvature_factor = interp(abs(kappa_cmd), [0.0007, 0.001], [self.low_gain_calc, self.high_gain_calc])
+    self.curvature_factor = interp(abs(kappa_cmd), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor
     path_angle = path_angle_calc

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -141,10 +141,9 @@ class LateralAngleExt:
   def __init__(self, CP=None, CP_SP=None):
     # Predicted-curvature blend for path_angle: pred * b + desired * (1-b); b from ``FordPathAngleBlendRatio``
     self.path_angle_blend_ratio = _FORD_PATH_ANGLE_BLEND_RATIO_DEFAULT
-    # Low pass filter values used in calculating kappa
-    self.speed_factor = None  #initialize as None, assign raw value on first cycle then filter
-    self.kappa_factor = None
-    self.b_blend = None
+    # Low pass filter values
+    self.b_blend = None  #initialize as None, assign raw value on first cycle then filter
+    self.kappa_gain_filt = None
     # Max extra VLT above t_base; from ``FordVLTExtraMax`` param
     self.vlt_extra_max = _VLT_T_EXTRA_MAX
     # Telemetry: final path_angle (rad) after limits (see bp_card_publisher)
@@ -404,30 +403,18 @@ class LateralAngleExt:
     # to command max path_angle through the entire apex. 0.15s gives t_base ≤ 0.20s and VLT ≤ 0.33s, restoring
     # the 2.8m lookahead that kept kappa_entering False at the apex in successful earlier runs.
     _t_base = float(clip(self.sm['liveDelay'].lateralDelay, 0.1, 0.15)) + _DT_MDL
-    target_speed_factor = float(interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [1.0, 0.0]))
-    #Low Pass Filter for _speed_factor calculation
-    if self.speed_factor is None:
-      self.speed_factor = target_speed_factor
-    else:
-      self.speed_factor = 0.80 * self.speed_factor + 0.20 * target_speed_factor
-    _speed_factor = float(clip(self.speed_factor, 0.0, 1.0))
+    _speed_factor = float(interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [1.0, 0.0]))
     # Direction-aware kappa factor: on curve ENTRY (model shows more curvature at t_base than planner now),
     # keep full lookahead so pre-steering begins early. On exit/apex, taper by magnitude to prevent unwind.
     _kappa_at_t_base = 0.0
     if self.model is not None and len(self.model.orientationRate.z) >= 17:
       _curvatures_ref = np.array(self.model.orientationRate.z) / max(0.01, v_ego)
       _kappa_at_t_base = abs(float(interp(_t_base, ModelConstants.T_IDXS, _curvatures_ref)))
-    _kappa_entering = _kappa_at_t_base > abs(desired_curvature) * 1.05
+    _kappa_entering = _kappa_at_t_base > abs(desired_curvature)
     if _kappa_entering:
-      target_kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
+      _kappa_factor = 1.0  # curve deepening ahead: full extra lookahead for gradual entry
     else:
-      target_kappa_factor = float(interp(abs(desired_curvature), [_VLT_KAPPA_FULL, _VLT_KAPPA_TAPER], [1.0, 0.0]))
-    #Low Pass Filter for _kappa_factor calculation
-    if self.kappa_factor is None:
-      self.kappa_factor = target_kappa_factor
-    else:
-      self.kappa_factor = 0.80 * self.kappa_factor + 0.20 * target_kappa_factor
-    _kappa_factor = float(clip(self.kappa_factor, 0.0, 1.0))
+      _kappa_factor = float(interp(abs(desired_curvature), [_VLT_KAPPA_FULL, _VLT_KAPPA_TAPER], [1.0, 0.0]))
     
     curvature_lookup_time = _t_base + self.vlt_extra_max * _speed_factor * _kappa_factor
     self.bp_curvature_lookup_time = curvature_lookup_time
@@ -440,7 +427,8 @@ class LateralAngleExt:
       )
 
     b = float(clip(self.path_angle_blend_ratio, 0.0, 1.0))
-    b = interp(v_ego, [_VLT_V_LOW_MS, _VLT_V_HIGH_MS], [b, 0.0])
+    #fade b to 0 from 55mph to 60mph to transition to no predicted_curvature
+    b = interp(v_ego, [24.59, 26.82], [b, 0.0])
 
     # Exit-biased blend: near the PSCM authority limit or while the planner is actively
     # reducing curvature (exit detected), drop model prediction weight from 60% → ~15%.
@@ -465,7 +453,7 @@ class LateralAngleExt:
     # 0.04 (1/m)/s, collapsing the model blend on mild straightening instead of genuine exits.
     # Same bug class and fix as _PSCM_SAT_UNWIND_RATE and _soft_roc above.
     _desired_falling = (
-      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.95
+      abs(desired_curvature) < abs(self._desired_curvature_last) * 0.80
     )
     _on_exit_near_limit = not _kappa_entering and (_pscm_lim >= 1 or _in_hard_sat or _desired_falling)
 
@@ -474,7 +462,7 @@ class LateralAngleExt:
     if self.b_blend is None:
       self.b_blend = target_b_blend
     else:
-      self.b_blend = 0.80 * self.b_blend + 0.20 * target_b_blend
+      self.b_blend = 0.70 * self.b_blend + 0.30 * target_b_blend
     b_blend = float(clip(self.b_blend, 0.0, 1.0))
     
     requested_curvature = predicted_curvature * b_blend + desired_curvature * (1.0 - b_blend)
@@ -535,17 +523,20 @@ class LateralAngleExt:
 
     # Speed-interpolated gain: at low speed both curves use 1.0; at high speed the params take effect.
     self.low_gain_calc = interp(
-      v_ego, [11.18, 31.29], [1.00, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
+      v_ego, [13.41, 26.82], [1.00, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
     )
     self.high_gain_calc = interp(
-      v_ego, [11.18, 31.29], [(1.40 * self.low_speed_curv_factor), (1.20 * self.path_angle_gain_highC_highV * self.high_speed_curv_factor)]
+      v_ego, [13.41, 26.82], [(1.30 * self.low_speed_curv_factor), (1.10 * self.path_angle_gain_highC_highV * self.high_speed_curv_factor)]
     )
 
-    # Speed-interpolated curve-radius: lower the speed, tighter the curves. easing into transition
-    high_gain_boundary = interp(v_ego, [8.94, 13.41, 16.54, 31.29], [0.02, 0.0195, 0.018, 0.0035])
-
+    #Low pass filtered kappa_cmd used only for gain calc. Helps dampen oscillations if they start
+    if self.kappa_gain_filt is None:
+      self.kappa_gain_filt = kappa_cmd
+    else:
+      self.kappa_gain_filt = 0.70 * self.kappa_gain_filt + 0.30 * kappa_cmd
+      
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    self.curvature_factor = interp(abs(kappa_cmd), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
+    self.curvature_factor = interp(abs(self.kappa_gain_filt), [0.0005, 0.002], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor
     path_angle = path_angle_calc


### PR DESCRIPTION
### Purpose
Reduce predicted_curvature model noise on straightaway to combat some oscillations at the source rather than gain dampening.

### Changes
- b-blend
Step function to smooth out transition between low and high b_blend values.
- Gate _kappa_entering and desired_falling
Add a percentage delta and a min curvature value to the logic that sets these. Prevents them from flipping true/false constantly.
- Add on_straightaway
Add new variable that reduces predicted_curvature blend on straightaways to reduce model noise. Set using entering == false, falling == false, and curve is minimal.

### Notes
I'm treating 0.001 as the boundary for a meaningful curve that might warrant higher predictive blending.