### PR TITLE
Update curvature_factor interpolation

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -515,10 +515,9 @@ class LateralAngleExt:
     )
 
     # Speed-interpolated curve-radius: at low speed, dont need full gain until a much tighter curve
-    high_gain_boundary = interp(v_ego, [11.18, 31.29], [0.02, 0.0045])
+    high_gain_boundary = interp(v_ego, [11.18, 31.29], [0.015, 0.0035])
 
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    #self.curvature_factor = interp(abs(self.kappa_gain_filt), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
     self.curvature_factor = interp(abs(kappa_cmd), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/lateral_angle_ext.py
@@ -508,12 +508,18 @@ class LateralAngleExt:
 
     # Speed-interpolated gain: at low speed both curves use 1.0; at high speed the params take effect.
     self.low_gain_calc = interp(
-      v_ego, [13.5, 26.82], [1.0, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
+      v_ego, [11.18, 31.29], [1.00, (self.path_angle_gain_lowC_highV * self.user_dampening_factor)]
     )
-    self.high_gain_calc = interp(v_ego, [13.5, 26.82], [(1.30 * self.low_speed_curv_factor), (self.path_angle_gain_highC_highV * self.high_speed_curv_factor)])
+    self.high_gain_calc = interp(
+      v_ego, [11.18, 31.29], [(1.30 * self.low_speed_curv_factor), (self.path_angle_gain_highC_highV * self.high_speed_curv_factor)]
+    )
+
+    # Speed-interpolated curve-radius: at low speed, dont need full gain until a much tighter curve
+    high_gain_boundary = interp(v_ego, [11.18, 31.29], [0.02, 0.0045])
 
     # As the curve gets bigger, we will need a little boost to the signal to to not understeer
-    self.curvature_factor = interp(abs(kappa_cmd), [0.0007, 0.001], [self.low_gain_calc, self.high_gain_calc])
+    #self.curvature_factor = interp(abs(self.kappa_gain_filt), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
+    self.curvature_factor = interp(abs(kappa_cmd), [0.0005, high_gain_boundary], [self.low_gain_calc, self.high_gain_calc])
 
     path_angle_calc = kappa_cmd * v_ego * self.curvature_factor
     path_angle = path_angle_calc


### PR DESCRIPTION
### Purpose
Reduce oscillations through curves, particularly around 1000m-1600m radius.

### Changes
- Speed range
Modified speed interpolation ranges from 30-60 to 25-70.
- Extend curvature_factor kappa interpolation
Extend interpolation from .0007-.001 (1600m-1000m) to .0005-"high_gain_boundary" (2000m-variable). This makes the interpolation happen over a much larger interval, preventing the fast swings from low to high gain. Initial fast swing made car lurch on entering a curve, and if curve continued near previous interp range, oscillations would continue.
- New high_gain_boundary
Add high_gain_boundary that interpolates the high gain curve radius using speed. "High curvature" is very dependent on speed--using .02 (50m rad) at 25 mph (.255 g, considered fairly low) and .0045 (222m rad) at 70 mph (.45 g, considered moderately aggressive).

### Notes
- Could be worth increasing the top of the speed range to 80 mph to more fully encompass the speeds at which the comma is used.
- Since the max gains aren't applied until much tighter curves, the low and high speed gain factors need to be set a decent bit higher than before to make some of the medium-high tightness curves. Around 1.25 in my testing. Might warrant updating the per platform gain defaults if this makes it through.
