### PR TITLE
ford: fix combo cruise-button event storm on sustained hold

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/ford/carstate_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/carstate_ext.py
@@ -86,6 +86,10 @@ class CarStateExt:
     self.button_states = {button.event_type: False for button in BUTTONS}
     # Track which event type was actually emitted for combo buttons (to handle releases correctly)
     self.last_emitted_event = {}  # signal_name -> event_type
+    # BluePilot: per-raw-signal edge tracker for combo buttons (can_msg -> last raw pressed state).
+    # See the comment in update() -- this must be independent of button_states, which is shared
+    # across combo handlers and caused a spurious-event storm on any sustained hold. See #193.
+    self.prev_button_signal = {}
     # Track previous cruise state to detect transitions
     self.cruise_enabled_prev = False
     # Track if mainCruise was pressed recently (to handle delayed cruise enable)
@@ -113,6 +117,14 @@ class CarStateExt:
     cruise_just_enabled = cruise_enabled and not self.cruise_enabled_prev
     main_cruise_just_pressed = False
 
+    # BluePilot: track which combo can_msg signals we've already handled this update() call.
+    # BUTTONS intentionally lists two Button entries per combo signal (e.g. accelCruise and
+    # setCruise both point at CcAslButtnSetIncPress), so the loop below visits the same raw
+    # signal twice per frame. This must be declared here -- once per call -- not inside the loop:
+    # declaring it inside silently defeated the guard every single iteration, so it never actually
+    # deduplicated anything. See #193.
+    processed_signals = set()
+
     for button in BUTTONS:
       # Check if button signal is in the pressed state (value == 1)
       try:
@@ -122,39 +134,43 @@ class CarStateExt:
         # Signal not available in this frame, skip
         continue
 
-      # Handle combo buttons: emit only the appropriate event based on cruise state
-      # Track which signals we've already processed to avoid duplicate events
-      processed_signals = set()
+      # BluePilot: second Button entry for an already-handled combo signal this frame -- skip it
+      # outright rather than falling through to the regular-button handler below (see #193).
+      if button.can_msg in processed_signals:
+        continue
 
       # CcAslButtnSetIncPress: setCruise (9) when disabled, accelCruise (3) when enabled
-      if button.can_msg == "CcAslButtnSetIncPress" and button.can_msg not in processed_signals:
+      if button.can_msg == "CcAslButtnSetIncPress":
         processed_signals.add(button.can_msg)
         signal_state = state
-        prev_accel_state = self.button_states.get(3, False)  # accelCruise
-        prev_set_state = self.button_states.get(9, False)  # setCruise
+        # BluePilot: transition must be detected off this signal's own previous raw value, not off
+        # the derived button_states[3]/[9] slots -- those are shared with the DecPress combo
+        # handler below (both can emit setCruise), so comparing against them let a write made by
+        # the *other* handler look like this signal itself just transitioned. That cross-talk was
+        # self-sustaining for as long as a combo button was held: each handler kept "reacting" to
+        # the other's writes to the shared setCruise slot, firing a fresh spurious press/release
+        # pair almost every 100Hz frame -- observed as a rapid engage/cancel storm on a real
+        # sustained Set press. See #193.
+        transitioned = signal_state != self.prev_button_signal.get(button.can_msg, False)
+        self.prev_button_signal[button.can_msg] = signal_state
 
-        if signal_state and (prev_accel_state != signal_state or prev_set_state != signal_state):
+        if signal_state and transitioned:
           # Choose event type based on cruise state
-          if cruise_enabled:
-            event_type = 3  # accelCruise
-          else:
-            event_type = 9  # setCruise
+          event_type = 3 if cruise_enabled else 9  # accelCruise : setCruise
 
-          # Emit the appropriate event
-          if self.button_states.get(event_type, False) != signal_state:
-            event = structs.CarState.ButtonEvent.new_message()
-            event.type = event_type
-            event.pressed = signal_state
-            button_events.append(event)
-            # Remember which event type we emitted for this signal
-            self.last_emitted_event[button.can_msg] = event_type
+          event = structs.CarState.ButtonEvent.new_message()
+          event.type = event_type
+          event.pressed = True
+          button_events.append(event)
+          # Remember which event type we emitted for this signal
+          self.last_emitted_event[button.can_msg] = event_type
 
           # Update state for both event types
-          self.button_states[3] = signal_state  # accelCruise
-          self.button_states[9] = signal_state  # setCruise
-        elif not signal_state and (prev_accel_state != signal_state or prev_set_state != signal_state):
+          self.button_states[3] = True  # accelCruise
+          self.button_states[9] = True  # setCruise
+        elif not signal_state and transitioned:
           # Button released - emit release ONLY for the event type that was actually emitted on press
-          last_emitted = self.last_emitted_event.get(button.can_msg)
+          last_emitted = self.last_emitted_event.pop(button.can_msg, None)
           if last_emitted is not None:
             # Always emit release if we previously emitted a press event for this button
             # This ensures ICBM button timers are properly reset
@@ -162,42 +178,36 @@ class CarStateExt:
             event.type = last_emitted
             event.pressed = False
             button_events.append(event)
-          # Clear the tracking
-          self.last_emitted_event.pop(button.can_msg, None)
           # Update state for both event types
           self.button_states[3] = False  # accelCruise
           self.button_states[9] = False  # setCruise
         continue
 
       # CcAslButtnSetDecPress: setCruise (9) when disabled, decelCruise (4) when enabled
-      if button.can_msg == "CcAslButtnSetDecPress" and button.can_msg not in processed_signals:
+      if button.can_msg == "CcAslButtnSetDecPress":
         processed_signals.add(button.can_msg)
         signal_state = state
-        prev_decel_state = self.button_states.get(4, False)  # decelCruise
-        prev_set_state = self.button_states.get(9, False)  # setCruise
+        # BluePilot: see the CcAslButtnSetIncPress comment above -- same fix, same reason. #193.
+        transitioned = signal_state != self.prev_button_signal.get(button.can_msg, False)
+        self.prev_button_signal[button.can_msg] = signal_state
 
-        if signal_state and (prev_decel_state != signal_state or prev_set_state != signal_state):
+        if signal_state and transitioned:
           # Choose event type based on cruise state
-          if cruise_enabled:
-            event_type = 4  # decelCruise
-          else:
-            event_type = 9  # setCruise
+          event_type = 4 if cruise_enabled else 9  # decelCruise : setCruise
 
-          # Emit the appropriate event
-          if self.button_states.get(event_type, False) != signal_state:
-            event = structs.CarState.ButtonEvent.new_message()
-            event.type = event_type
-            event.pressed = signal_state
-            button_events.append(event)
-            # Remember which event type we emitted for this signal
-            self.last_emitted_event[button.can_msg] = event_type
+          event = structs.CarState.ButtonEvent.new_message()
+          event.type = event_type
+          event.pressed = True
+          button_events.append(event)
+          # Remember which event type we emitted for this signal
+          self.last_emitted_event[button.can_msg] = event_type
 
           # Update state for both event types
-          self.button_states[4] = signal_state  # decelCruise
-          self.button_states[9] = signal_state  # setCruise
-        elif not signal_state and (prev_decel_state != signal_state or prev_set_state != signal_state):
+          self.button_states[4] = True  # decelCruise
+          self.button_states[9] = True  # setCruise
+        elif not signal_state and transitioned:
           # Button released - emit release ONLY for the event type that was actually emitted on press
-          last_emitted = self.last_emitted_event.get(button.can_msg)
+          last_emitted = self.last_emitted_event.pop(button.can_msg, None)
           if last_emitted is not None:
             # Always emit release if we previously emitted a press event for this button
             # This ensures ICBM button timers are properly reset
@@ -205,42 +215,36 @@ class CarStateExt:
             event.type = last_emitted
             event.pressed = False
             button_events.append(event)
-          # Clear the tracking
-          self.last_emitted_event.pop(button.can_msg, None)
           # Update state for both event types
           self.button_states[4] = False  # decelCruise
           self.button_states[9] = False  # setCruise
         continue
 
       # CcAslButtnCnclResPress: cancel (5) when enabled, resumeCruise (10) when disabled
-      if button.can_msg == "CcAslButtnCnclResPress" and button.can_msg not in processed_signals:
+      if button.can_msg == "CcAslButtnCnclResPress":
         processed_signals.add(button.can_msg)
         signal_state = state
-        prev_cancel_state = self.button_states.get(5, False)  # cancel
-        prev_resume_state = self.button_states.get(10, False)  # resumeCruise
+        # BluePilot: see the CcAslButtnSetIncPress comment above -- same fix, same reason. #193.
+        transitioned = signal_state != self.prev_button_signal.get(button.can_msg, False)
+        self.prev_button_signal[button.can_msg] = signal_state
 
-        if signal_state and (prev_cancel_state != signal_state or prev_resume_state != signal_state):
+        if signal_state and transitioned:
           # Choose event type based on cruise state at the moment of press
-          if cruise_enabled:
-            event_type = 5  # cancel
-          else:
-            event_type = 10  # resumeCruise
+          event_type = 5 if cruise_enabled else 10  # cancel : resumeCruise
 
-          # Emit the appropriate event
-          if self.button_states.get(event_type, False) != signal_state:
-            event = structs.CarState.ButtonEvent.new_message()
-            event.type = event_type
-            event.pressed = signal_state
-            button_events.append(event)
-            # Remember which event type we emitted for this signal
-            self.last_emitted_event[button.can_msg] = event_type
+          event = structs.CarState.ButtonEvent.new_message()
+          event.type = event_type
+          event.pressed = True
+          button_events.append(event)
+          # Remember which event type we emitted for this signal
+          self.last_emitted_event[button.can_msg] = event_type
 
           # Update state for both event types
-          self.button_states[5] = signal_state  # cancel
-          self.button_states[10] = signal_state  # resumeCruise
-        elif not signal_state and (prev_cancel_state != signal_state or prev_resume_state != signal_state):
+          self.button_states[5] = True  # cancel
+          self.button_states[10] = True  # resumeCruise
+        elif not signal_state and transitioned:
           # Button released - emit release ONLY for the event type that was actually emitted on press
-          last_emitted = self.last_emitted_event.get(button.can_msg)
+          last_emitted = self.last_emitted_event.pop(button.can_msg, None)
           if last_emitted is not None:
             # Always emit release if we previously emitted a press event for this button
             # This ensures ICBM button timers are properly reset
@@ -248,8 +252,6 @@ class CarStateExt:
             event.type = last_emitted
             event.pressed = False
             button_events.append(event)
-          # Clear the tracking
-          self.last_emitted_event.pop(button.can_msg, None)
           # Update state for both event types
           self.button_states[5] = False  # cancel
           self.button_states[10] = False  # resumeCruise

--- a/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_carstate_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/ford/tests/test_carstate_ext.py
@@ -1,0 +1,112 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+# Regression test for BluePilotDev/bluepilot#193: holding a Ford combo cruise button
+# (Set+Inc/Set+Dec/Cancel+Res) produced a self-sustaining stream of spurious press/release
+# events every frame, because the "did my signal change" check compared against derived,
+# shared button_states slots instead of each raw signal's own previous value. See the
+# comments in CarStateExt.update() for the full mechanism.
+
+import unittest
+
+from opendbc.car import Bus, structs
+from opendbc.sunnypilot.car.ford.carstate_ext import CarStateExt
+
+ButtonType = structs.CarState.ButtonEvent.Type
+
+
+class _FakeCANParser:
+  def __init__(self, vl):
+    self.vl = vl
+
+
+def _cs(cruise_enabled: bool) -> structs.CarState:
+  ret = structs.CarState.new_message()
+  ret.cruiseState.enabled = cruise_enabled
+  return ret
+
+
+def _parsers(dec_press: int, inc_press: int = 0, cncl_res_press: int = 0, on_off_press: int = 0):
+  vl = {
+    "Steering_Data_FD1": {
+      "CcAslButtnSetDecPress": dec_press,
+      "CcAslButtnSetIncPress": inc_press,
+      "CcAslButtnCnclResPress": cncl_res_press,
+      "CcButtnOnOffPress": on_off_press,
+    },
+  }
+  return {Bus.pt: _FakeCANParser(vl)}
+
+
+class TestComboButtonEvents(unittest.TestCase):
+  def setUp(self):
+    self.ext = CarStateExt(structs.CarParams(), structs.CarParamsSP())
+
+  def _events(self):
+    return [(e.type, e.pressed) for e in self.ext.button_events]
+
+  def test_sustained_hold_emits_exactly_one_press_and_one_release(self):
+    """The core #193 regression: holding Set+Dec should emit exactly one press event
+    (on the rising edge) and exactly one release event (on the falling edge) -- not a
+    fresh press/release pair every single frame it stays held."""
+    ret = _cs(cruise_enabled=False)
+
+    # Rising edge.
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1))
+    self.assertEqual(self._events(), [(ButtonType.setCruise, True)])
+
+    # Held steady for many frames: must be silent every time.
+    for _ in range(50):
+      self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1))
+      self.assertEqual(self._events(), [], "spurious event while button held steady (#193)")
+
+    # Cruise engages partway through the hold (as it would in the real failure) -- still silent.
+    ret = _cs(cruise_enabled=True)
+    for _ in range(20):
+      self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1))
+      self.assertEqual(self._events(), [], "spurious event after cruise_enabled changed mid-hold (#193)")
+
+    # Falling edge: exactly one release, for the event type that was actually emitted on press.
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=0))
+    self.assertEqual(self._events(), [(ButtonType.setCruise, False)])
+
+  def test_inc_and_dec_do_not_cross_contaminate_setcruise(self):
+    """Holding Set+Dec (emitting setCruise) must not be disturbed by the Inc signal's own
+    steady 0 state being reprocessed each frame -- the original bug's exact mechanism."""
+    ret = _cs(cruise_enabled=False)
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1, inc_press=0))
+    self.assertEqual(self._events(), [(ButtonType.setCruise, True)])
+
+    for _ in range(10):
+      self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1, inc_press=0))
+      self.assertEqual(self._events(), [])
+
+  def test_tap_while_engaged_emits_decel_not_setcruise(self):
+    """A quick tap while cruise is already enabled should emit decelCruise, matching stock
+    adjust-speed behavior -- unaffected by the fix."""
+    ret = _cs(cruise_enabled=True)
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=1))
+    self.assertEqual(self._events(), [(ButtonType.decelCruise, True)])
+
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=0))
+    self.assertEqual(self._events(), [(ButtonType.decelCruise, False)])
+
+  def test_cancel_resume_combo_unaffected(self):
+    ret = _cs(cruise_enabled=True)
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=0, cncl_res_press=1))
+    self.assertEqual(self._events(), [(ButtonType.cancel, True)])
+
+    for _ in range(10):
+      self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=0, cncl_res_press=1))
+      self.assertEqual(self._events(), [])
+
+    self.ext.update(ret, structs.CarStateSP(), _parsers(dec_press=0, cncl_res_press=0))
+    self.assertEqual(self._events(), [(ButtonType.cancel, False)])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Holding a Ford combo cruise button (Set+Inc, Set+Dec, or Cancel+Res) produced a self-sustaining stream of spurious press/release events every ~10ms frame instead of one clean press and one clean release, observed as the cluster flashing the set speed then immediately canceling -- confirmed via raw CAN decode that the physical signal itself was a single clean pulse the whole time, so this was entirely a software bug, not chatter or a bad connection.

Two compounding defects in CarStateExt.update():

1. processed_signals = set() was declared inside the per-button loop, not once per update() call, so it never actually deduped anything -- BUTTONS lists two entries per combo signal (e.g. accelCruise and setCruise both point at CcAslButtnSetIncPress), so each combo block ran twice per frame.

2. The real cause of the storm: each combo handler detected "did my signal change" by comparing against the derived, shared button_states[3]/[4]/[9]/[5]/[10] slots, not the raw signal's own previous value. Since setCruise (9) is written by both the Inc and Dec handlers, a write from one handler looked like a transition to the other, which reset the shared slot back out from under it -- causing each handler to alternately "detect" a phantom edge and re-fire for as long as the button stayed physically held.

Fix: track each raw combo signal's own previous state independently (self.prev_button_signal, keyed by can_msg) instead of inferring transitions from the shared derived state, and fix the loop-scoping bug so each signal is only ever processed once per frame. Added opendbc/sunnypilot/car/ford/tests/test_carstate_ext.py, which fails against the pre-fix code (verified) and passes against this fix.

BluePilotDev/bluepilot#193.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

